### PR TITLE
feat: 카테고리 리스트 조회, 지역 리스트 조회 구현

### DIFF
--- a/src/main/java/com/example/newfieldpasser/controller/CategoryController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/CategoryController.java
@@ -1,0 +1,19 @@
+package com.example.newfieldpasser.controller;
+
+import com.example.newfieldpasser.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping("/category")
+    public ResponseEntity<?> categoryInquiry() {
+        return categoryService.categoryInquiry();
+    }
+}

--- a/src/main/java/com/example/newfieldpasser/controller/DistrictController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/DistrictController.java
@@ -1,0 +1,19 @@
+package com.example.newfieldpasser.controller;
+
+import com.example.newfieldpasser.service.DistrictService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class DistrictController {
+
+    private final DistrictService districtService;
+
+    @GetMapping("/district")
+    public ResponseEntity<?> districtInquiry() {
+        return districtService.districtInquiry();
+    }
+}

--- a/src/main/java/com/example/newfieldpasser/dto/CategoryDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/CategoryDTO.java
@@ -1,0 +1,23 @@
+package com.example.newfieldpasser.dto;
+
+import com.example.newfieldpasser.entity.Category;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CategoryDTO {
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class CategoryResponseDTO {
+        private int categoryId;
+        private String categoryName;
+
+        @Builder
+        public CategoryResponseDTO(Category category) {
+            this.categoryId = category.getCategoryId();
+            this.categoryName = category.getCategoryName();
+        }
+    }
+}

--- a/src/main/java/com/example/newfieldpasser/dto/DistrictDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/DistrictDTO.java
@@ -1,0 +1,23 @@
+package com.example.newfieldpasser.dto;
+
+import com.example.newfieldpasser.entity.District;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class DistrictDTO {
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class DistrictResponseDTO {
+        private int districtId;
+        private String districtName;
+
+        @Builder
+        public DistrictResponseDTO(District district) {
+            this.districtId = district.getDistrictId();
+            this.districtName = district.getDistrictName();
+        }
+    }
+}

--- a/src/main/java/com/example/newfieldpasser/repository/CategoryRepository.java
+++ b/src/main/java/com/example/newfieldpasser/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.newfieldpasser.repository;
+
+import com.example.newfieldpasser.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Integer> {
+}

--- a/src/main/java/com/example/newfieldpasser/repository/DistrictRepository.java
+++ b/src/main/java/com/example/newfieldpasser/repository/DistrictRepository.java
@@ -1,0 +1,8 @@
+package com.example.newfieldpasser.repository;
+
+import com.example.newfieldpasser.entity.District;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DistrictRepository extends JpaRepository<District, Integer> {
+
+}

--- a/src/main/java/com/example/newfieldpasser/service/CategoryService.java
+++ b/src/main/java/com/example/newfieldpasser/service/CategoryService.java
@@ -1,0 +1,29 @@
+package com.example.newfieldpasser.service;
+
+import com.example.newfieldpasser.dto.CategoryDTO;
+import com.example.newfieldpasser.dto.Response;
+import com.example.newfieldpasser.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final Response response;
+
+    public ResponseEntity<?> categoryInquiry() {
+        List<CategoryDTO.CategoryResponseDTO> result = categoryRepository.findAll()
+                .stream()
+                .map(CategoryDTO.CategoryResponseDTO::new)
+                .collect(Collectors.toList());
+
+        return response.success(result);
+    }
+
+}

--- a/src/main/java/com/example/newfieldpasser/service/DistrictService.java
+++ b/src/main/java/com/example/newfieldpasser/service/DistrictService.java
@@ -1,0 +1,29 @@
+package com.example.newfieldpasser.service;
+
+import com.example.newfieldpasser.dto.CategoryDTO;
+import com.example.newfieldpasser.dto.DistrictDTO;
+import com.example.newfieldpasser.dto.Response;
+import com.example.newfieldpasser.repository.DistrictRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class DistrictService {
+
+    private final DistrictRepository districtRepository;
+    private final Response response;
+
+    public ResponseEntity<?> districtInquiry() {
+        List<DistrictDTO.DistrictResponseDTO> result = districtRepository.findAll()
+                .stream()
+                .map(DistrictDTO.DistrictResponseDTO::new)
+                .collect(Collectors.toList());
+
+        return response.success(result);
+    }
+}


### PR DESCRIPTION
## Motivation

카테고리 리스트 조회, 지역 리스트 조회 구현
카테고리는 풋살장,축구장,농구장,배드민턴장,테니스장
지역은 서울지역으로 한정
'1','강남구'
'2','강동구'
'3','강서구'
'4','광진구'
'5','구로구'
'6','동대문구'
'7','동작구'
'8','마포구'
'9','서초구'
'10','성동구'
'11','성북구'
'12','송파구'
'13','양천구'
'14','영등포구'
'15','용산구'
'16','종로구'
'17','중구'

## Key Changes

- 카테고리 리스트 조회
- 지역 리스트 조회

## To reviewers

<!-- 이 PR을 확인할 Code Reviewer에게 남길 메시지
- 객체 연관관계가 잘 고려되었는지를 중점적으로 봐주세요
-->
