### PR TITLE
feat: 게시글 상세조회 기능 구현

### DIFF
--- a/src/main/java/com/example/newfieldpasser/config/SecurityConfig.java
+++ b/src/main/java/com/example/newfieldpasser/config/SecurityConfig.java
@@ -72,6 +72,7 @@ public class SecurityConfig {
 
                 .and()
                 .authorizeRequests() // '인증'이 필요하다
+                .antMatchers("/board/**").authenticated()// 게시글 관련 인증 필요
                 //.antMatchers("/api/mypage/**").authenticated() // 마이페이지 인증 필요
                 //.antMatchers("/api/admin/**").hasRole("ADMIN") // 관리자 페이지
                 .anyRequest().permitAll()

--- a/src/main/java/com/example/newfieldpasser/controller/BoardController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/BoardController.java
@@ -5,10 +5,7 @@ import com.example.newfieldpasser.service.BoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -26,5 +23,16 @@ public class BoardController {
                                            BoardDTO.boardReqDTO boardReqDTO) {
 
         return boardService.registerBoard(file, authentication, boardReqDTO);
+    }
+
+    /*
+    게시글 상세조회
+     */
+    @GetMapping("/board/{boardId}")
+    public ResponseEntity<?> registerBoard(@PathVariable long boardId) {
+        // 상세조회 시 조회 수 카운트
+        boardService.updateViewCount(boardId);
+
+        return boardService.boardInquiryDetail(boardId);
     }
 }

--- a/src/main/java/com/example/newfieldpasser/dto/BoardDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/BoardDTO.java
@@ -5,10 +5,7 @@ import com.example.newfieldpasser.entity.Category;
 import com.example.newfieldpasser.entity.District;
 import com.example.newfieldpasser.entity.Member;
 import com.example.newfieldpasser.parameter.TransactionStatus;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
@@ -44,6 +41,49 @@ public class BoardDTO {
                     .transactionStatus(transactionStatus)
                     .price(price)
                     .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class boardResDTO {
+        private long boardId;
+        private String memberName;
+        private String categoryName;
+        private String districtName;
+        private String title;
+        private String content;
+        private LocalDateTime registerDate;
+        private LocalDateTime startTime;
+        private LocalDateTime endTime;
+        private String imageUrl;
+        private TransactionStatus transactionStatus;
+        private int price;
+        private String phone;
+        private int viewCount;
+        private int wishCount;
+        private boolean blind;
+        private boolean deleteCheck;
+
+        @Builder
+        public boardResDTO(Board board) {
+            this.boardId = board.getBoardId();
+            this.memberName = board.getMember().getMemberName();
+            this.categoryName = board.getCategory().getCategoryName();
+            this.districtName = board.getDistrict().getDistrictName();
+            this.title = board.getTitle();
+            this.content = board.getContent();
+            this.registerDate = board.getRegisterDate();
+            this.startTime = board.getStartTime();
+            this.endTime = board.getEndTime();
+            this.imageUrl = board.getImageUrl();
+            this.transactionStatus = board.getTransactionStatus();
+            this.price = board.getPrice();
+            this.phone = board.getMember().getMemberPhone();
+            this.viewCount = board.getViewCount();
+            this.wishCount = board.getWishCount();
+            this.blind = board.isBlind();
+            this.deleteCheck = board.isDeleteCheck();
         }
     }
 }

--- a/src/main/java/com/example/newfieldpasser/exception/board/BoardException.java
+++ b/src/main/java/com/example/newfieldpasser/exception/board/BoardException.java
@@ -1,0 +1,30 @@
+package com.example.newfieldpasser.exception.board;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BoardException extends RuntimeException{
+
+    private ErrorCode errorCode;
+    private String message;
+
+    public BoardException(ErrorCode err){
+        this.errorCode = err;
+    }
+
+    @Override
+    public String getMessage(){
+        if(message == null){
+            return "{" +
+                    "\"state\":" + "\"" + errorCode.getStatus() + "\"" + "\n" +
+                    "\t" + "\"message\":" + errorCode.getMessage() +
+                    "}";
+        }
+        return "{" +
+                "\"state\":" + "\"" + errorCode.getStatus() + "\"" + "\n" +
+                "\t" + "\"message\":" + message +
+                "}";
+    }
+}

--- a/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
+++ b/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
@@ -1,0 +1,12 @@
+package com.example.newfieldpasser.exception.board;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    BOARD_INQUIRY_DETAIL_FAIL(HttpStatus.BAD_REQUEST, "Board Inquiry Failed!");
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/example/newfieldpasser/repository/BoardRepository.java
+++ b/src/main/java/com/example/newfieldpasser/repository/BoardRepository.java
@@ -2,6 +2,16 @@ package com.example.newfieldpasser.repository;
 
 import com.example.newfieldpasser.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    Optional<Board> findByBoardId(long boardId);
+    @Modifying
+    @Query("update Board b set b.viewCount = b.viewCount + 1 where b.boardId = :boardId")
+    void updateViewCount(@Param("boardId") long boardId);
 }

--- a/src/main/java/com/example/newfieldpasser/service/BoardService.java
+++ b/src/main/java/com/example/newfieldpasser/service/BoardService.java
@@ -7,6 +7,8 @@ import com.example.newfieldpasser.dto.Response;
 import com.example.newfieldpasser.entity.Category;
 import com.example.newfieldpasser.entity.District;
 import com.example.newfieldpasser.entity.Member;
+import com.example.newfieldpasser.exception.board.BoardException;
+import com.example.newfieldpasser.exception.board.ErrorCode;
 import com.example.newfieldpasser.repository.BoardRepository;
 import com.example.newfieldpasser.repository.CategoryRepository;
 import com.example.newfieldpasser.repository.DistrictRepository;
@@ -39,6 +41,9 @@ public class BoardService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+    /*
+    게시글 등록
+     */
     @Transactional
     public ResponseEntity<?> registerBoard(MultipartFile file, Authentication authentication, BoardDTO.boardReqDTO boardReqDTO) {
         try {
@@ -77,4 +82,29 @@ public class BoardService {
 
         return amazonS3.getUrl(bucket, fullName).toString();
     }
+
+    /*
+    게시글 조회 시 조회 수 카운트
+     */
+    @Transactional
+    public void updateViewCount(long boardId) {
+        boardRepository.updateViewCount(boardId);
+    }
+
+    /*
+    게시글 상세조회
+     */
+    public ResponseEntity<?> boardInquiryDetail(long boardId) {
+        try {
+            BoardDTO.boardResDTO result = boardRepository.findByBoardId(boardId).map(BoardDTO.boardResDTO::new).get();
+
+            return response.success(result, "Board Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("게시글 상세조회 실패!");
+            e.printStackTrace();
+            throw new BoardException(ErrorCode.BOARD_INQUIRY_DETAIL_FAIL);
+        }
+    }
+
 }


### PR DESCRIPTION
## Motivation

게시글 상세조회 기능 구현
게시글 상세조회 시 조회 수 카운트 되도록 update 쿼리 날아가게 구현했습니다.
더 좋은 방법이 있을지 고민해보는 중입니다.
추가로 게시글 관련 접근은 회원만 가능하도록 변경해두었습니다.

## Key Changes

- 게시글 상세조회 기능 구현
- 게시글 상세조회 시 조회 수 카운트 기능 구현
- 시큐리티 관련 설정 변경


## To reviewers

코드 확인부탁드립니다 !
