### PR TITLE
feat: 게시글 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/newfieldpasser/controller/BoardController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/BoardController.java
@@ -35,4 +35,16 @@ public class BoardController {
 
         return boardService.boardInquiryDetail(boardId);
     }
+
+    /*
+    게시글 수정
+     */
+    @PutMapping("/board/edit/{boardId}")
+    public ResponseEntity<?> editBoard(@PathVariable long boardId,
+                                       @RequestParam("file") MultipartFile file,
+                                       BoardDTO.boardReqDTO boardReqDTO) {
+
+        return boardService.editBoard(boardId,file,boardReqDTO);
+    }
+
 }

--- a/src/main/java/com/example/newfieldpasser/dto/BoardDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/BoardDTO.java
@@ -48,6 +48,7 @@ public class BoardDTO {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class boardResDTO {
         private long boardId;
+        private String memberId;
         private String memberName;
         private String categoryName;
         private String districtName;
@@ -68,6 +69,7 @@ public class BoardDTO {
         @Builder
         public boardResDTO(Board board) {
             this.boardId = board.getBoardId();
+            this.memberId = board.getMember().getMemberId();
             this.memberName = board.getMember().getMemberName();
             this.categoryName = board.getCategory().getCategoryName();
             this.districtName = board.getDistrict().getDistrictName();

--- a/src/main/java/com/example/newfieldpasser/entity/Board.java
+++ b/src/main/java/com/example/newfieldpasser/entity/Board.java
@@ -92,4 +92,18 @@ public class Board {
         this.viewCount = this.viewCount == null ? 0 : this.viewCount;
         this.wishCount = this.wishCount == null ? 0 : this.wishCount;
     }
+
+    public void updatePost(Category category, District district, String imageUrl,
+                           String title, String content, LocalDateTime startTime,
+                           LocalDateTime endTime, TransactionStatus transactionStatus, int price) {
+        this.category = category;
+        this.district = district;
+        this.imageUrl = imageUrl;
+        this.title = title;
+        this.content = content;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.transactionStatus = transactionStatus;
+        this.price = price;
+    }
 }

--- a/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
+++ b/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    BOARD_INQUIRY_DETAIL_FAIL(HttpStatus.BAD_REQUEST, "Board Inquiry Failed!");
+    BOARD_INQUIRY_DETAIL_FAIL(HttpStatus.BAD_REQUEST, "Board Inquiry Failed!"),
+    BOARD_EDIT_FAIL(HttpStatus.BAD_REQUEST, "Board Edit Failed!");
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/com/example/newfieldpasser/service/BoardService.java
+++ b/src/main/java/com/example/newfieldpasser/service/BoardService.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.example.newfieldpasser.dto.BoardDTO;
 import com.example.newfieldpasser.dto.Response;
+import com.example.newfieldpasser.entity.Board;
 import com.example.newfieldpasser.entity.Category;
 import com.example.newfieldpasser.entity.District;
 import com.example.newfieldpasser.entity.Member;
@@ -104,6 +105,33 @@ public class BoardService {
             log.error("게시글 상세조회 실패!");
             e.printStackTrace();
             throw new BoardException(ErrorCode.BOARD_INQUIRY_DETAIL_FAIL);
+        }
+    }
+
+    /*
+    게시글 수정
+     */
+    @Transactional
+    public ResponseEntity<?> editBoard(long boardId, MultipartFile file, BoardDTO.boardReqDTO boardReqDTO) {
+        try {
+
+            Board board = boardRepository.findByBoardId(boardId).get();
+            String changedImageUrl = uploadPic(file);
+            Category category = categoryRepository.findByCategoryName(boardReqDTO.getCategoryName()).get();
+            District district = districtRepository.findByDistrictName(boardReqDTO.getDistrictName()).get();
+
+            board.updatePost(category, district, changedImageUrl,
+                    boardReqDTO.getTitle(), boardReqDTO.getContent(), boardReqDTO.getStartTime(),
+                    boardReqDTO.getEndTime(), boardReqDTO.getTransactionStatus(), boardReqDTO.getPrice());
+
+            return response.success("Edit Board Success!");
+
+        } catch (IOException e) {
+            log.error("Fail Upload file!");
+            return response.fail("Fail Upload file!");
+        } catch (BoardException e) {
+            log.error("게시글 수정 실패!");
+            throw new BoardException(ErrorCode.BOARD_EDIT_FAIL);
         }
     }
 


### PR DESCRIPTION
## Motivation

게시글 수정 기능 구현하였습니다.
해당 API 또한 첨부파일 존재하여 폼데이터로 전달
게시글 수정은 글 쓴 본인만 접근할 수 있도록 프론트에서 처리
상세조회 DTO에 멤버 아이디 추가하였습니다.

## Key Changes

- 게시글 수정 기능 구현

## To reviewers

<!-- 이 PR을 확인할 Code Reviewer에게 남길 메시지
- 객체 연관관계가 잘 고려되었는지를 중점적으로 봐주세요
-->
