### PR TITLE
feat: 게시글 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/newfieldpasser/controller/BoardController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/BoardController.java
@@ -29,7 +29,7 @@ public class BoardController {
     게시글 상세조회
      */
     @GetMapping("/board/{boardId}")
-    public ResponseEntity<?> registerBoard(@PathVariable long boardId) {
+    public ResponseEntity<?> boardInquiryDetail(@PathVariable long boardId) {
         // 상세조회 시 조회 수 카운트
         boardService.updateViewCount(boardId);
 
@@ -54,5 +54,45 @@ public class BoardController {
     public ResponseEntity<?> deleteBoard(@PathVariable long boardId) {
 
         return boardService.deleteBoard(boardId);
+    }
+
+    /*
+    게시글 리스트 조회
+     */
+    @GetMapping("/board/list/{page}")
+    public ResponseEntity<?> boardListInquiry(@PathVariable int page) {
+
+        return boardService.boardListInquiry(page);
+    }
+
+    /*
+    게시글 리스트 조회 - 카테고리별
+     */
+    @GetMapping("/board/list/category/{categoryId}/{page}")
+    public ResponseEntity<?> boardListInquiryByCategory(@PathVariable int categoryId,
+                                                        @PathVariable int page) {
+
+        return boardService.boardListInquiryByCategory(categoryId, page);
+    }
+
+    /*
+    게시글 리스트 조회 - 지역별
+     */
+    @GetMapping("/board/list/district/{districtId}/{page}")
+    public ResponseEntity<?> boardListInquiryByDistrict(@PathVariable int districtId,
+                                                        @PathVariable int page) {
+
+        return boardService.boardListInquiryByDistrict(districtId, page);
+    }
+
+    /*
+    게시글 리스트 조회 - 카테고리 + 지역
+     */
+    @GetMapping("/board/list/category-district/{categoryId}/{districtId}/{page}")
+    public ResponseEntity<?> boardListInquiryByCategoryAndDistrict(@PathVariable int categoryId,
+                                                                   @PathVariable int districtId,
+                                                                   @PathVariable int page) {
+
+        return boardService.boardListInquiryByCategoryAndDistrict(categoryId, districtId, page);
     }
 }

--- a/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
+++ b/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     BOARD_INQUIRY_DETAIL_FAIL(HttpStatus.BAD_REQUEST, "Board Inquiry Failed!"),
     BOARD_EDIT_FAIL(HttpStatus.BAD_REQUEST, "Board Edit Failed!"),
-    BOARD_DELETE_FAIL(HttpStatus.BAD_REQUEST, "Board Delete Failed!");
+    BOARD_DELETE_FAIL(HttpStatus.BAD_REQUEST, "Board Delete Failed!"),
+    BOARD_LIST_INQUIRY_FAIL(HttpStatus.BAD_REQUEST, "BoardList Inquiry Failed!");
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/com/example/newfieldpasser/repository/BoardRepository.java
+++ b/src/main/java/com/example/newfieldpasser/repository/BoardRepository.java
@@ -1,6 +1,9 @@
 package com.example.newfieldpasser.repository;
 
 import com.example.newfieldpasser.entity.Board;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +20,18 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Modifying
     void deleteByBoardId(@Param("boardId") long boardId);
+
+    @EntityGraph(attributePaths = {"member","category","district"})
+    @Query("select b from Board b")
+    Slice<Board> findDefaultAll(PageRequest pageRequest);
+
+    @EntityGraph(attributePaths = {"member","category","district"})
+    Slice<Board> findByCategory_CategoryId(int categoryId, PageRequest pageRequest);
+
+    @EntityGraph(attributePaths = {"member","category","district"})
+    Slice<Board> findByDistrict_DistrictId(int districtId, PageRequest pageRequest);
+
+    @EntityGraph(attributePaths = {"member","category","district"})
+    Slice<Board> findByCategory_CategoryIdAndDistrict_DistrictId(int categoryId, int districtId, PageRequest pageRequest);
+
 }

--- a/src/main/java/com/example/newfieldpasser/service/BoardService.java
+++ b/src/main/java/com/example/newfieldpasser/service/BoardService.java
@@ -17,6 +17,9 @@ import com.example.newfieldpasser.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -152,4 +155,80 @@ public class BoardService {
         }
     }
 
+    /*
+    게시글 리스트 조회
+     */
+    public ResponseEntity<?> boardListInquiry(int page) {
+        try {
+
+            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
+
+            Slice<BoardDTO.boardResDTO> boardList =
+                    boardRepository.findDefaultAll(pageRequest).map(BoardDTO.boardResDTO::new);
+
+            return response.success(boardList, "Board Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("게시글 리스트 조회 실패!");
+            throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
+        }
+    }
+
+    /*
+    게시글 리스트 조회 - 카테고리별
+     */
+    public ResponseEntity<?> boardListInquiryByCategory(int categoryId, int page) {
+        try {
+
+            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
+
+            Slice<BoardDTO.boardResDTO> boardList =
+                    boardRepository.findByCategory_CategoryId(categoryId, pageRequest).map(BoardDTO.boardResDTO::new);
+
+            return response.success(boardList, "Board Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("게시글 리스트 조회 실패!");
+            throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
+        }
+    }
+
+    /*
+    게시글 리스트 조회 - 지역별
+     */
+    public ResponseEntity<?> boardListInquiryByDistrict(int districtId, int page) {
+        try {
+
+            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
+
+            Slice<BoardDTO.boardResDTO> boardList =
+                    boardRepository.findByDistrict_DistrictId(districtId, pageRequest).map(BoardDTO.boardResDTO::new);
+
+            return response.success(boardList, "Board Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("게시글 리스트 조회 실패!");
+            throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
+        }
+    }
+
+    /*
+    게시글 리스트 조회 - 카테고리 + 지역
+     */
+    public ResponseEntity<?> boardListInquiryByCategoryAndDistrict(int categoryId, int districtId, int page) {
+        try {
+
+            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
+
+            Slice<BoardDTO.boardResDTO> boardList =
+                    boardRepository.findByCategory_CategoryIdAndDistrict_DistrictId(categoryId, districtId, pageRequest)
+                            .map(BoardDTO.boardResDTO::new);
+
+            return response.success(boardList, "Board Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("게시글 리스트 조회 실패!");
+            throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
+        }
+    }
 }


### PR DESCRIPTION
## Motivation

게시글 리스트 조회 기능 구현하였습니다.
네 가지 방법으로 조회 가능합니다.

전체 조회 - 카테고리,지역 상관없이 등록된 날짜 순으로 조회합니다.
카테고리별 조회 - 카테고리 아이디를 받아 조회합니다. 등록된 날짜 순으로 조회합니다.
지역별 조회 - 지역 아이디를 받아 조회합니다. 등록된 날짜 순으로 조회합니다.
카테고리 + 지역으로 조회 - 카테고리, 지역 아이디를 받아 조회합니다. 등록된 날짜 순으로 조회합니다.

## Key Changes

- 게시글 리스트 전체 조회
- 게시글 리스트 카테고리별 조회
- 게시글 리스트 지역별 조회
- 게시글 리스트 카테고리 + 지역으로 조회

## To reviewers

코드 확인 부탁드립니다 !

