### PR TITLE
feat: 제목으로 게시글 리스트 검색 기능 구현

### DIFF
--- a/src/main/java/com/example/newfieldpasser/controller/BoardController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/BoardController.java
@@ -95,4 +95,48 @@ public class BoardController {
 
         return boardService.boardListInquiryByCategoryAndDistrict(categoryId, districtId, page);
     }
+
+    /*
+    게시글 리스트 제목으로 검색
+     */
+    @GetMapping("/board/search-title/{page}")
+    public ResponseEntity<?> boardListInquiryByTitle(@RequestParam(name = "title") String title,
+                                                     @PathVariable int page) {
+
+        return boardService.boardListInquiryByTitle(title, page);
+    }
+
+    /*
+    게시글 리스트 제목 + 카테고리로 검색
+     */
+    @GetMapping("/board/search-title-category/{categoryId}/{page}")
+    public ResponseEntity<?> boardListInquiryByTitleAndCategory(@RequestParam(name = "title") String title,
+                                                                @PathVariable int categoryId,
+                                                                @PathVariable int page) {
+
+        return boardService.boardListInquiryByTitleAndCategory(title, categoryId, page);
+    }
+
+    /*
+    게시글 리스트 제목 + 지역으로 검색
+     */
+    @GetMapping("/board/search-title-district/{districtId}/{page}")
+    public ResponseEntity<?> boardListInquiryByTitleAndDistrict(@RequestParam(name = "title") String title,
+                                                                @PathVariable int districtId,
+                                                                @PathVariable int page) {
+
+        return boardService.boardListInquiryByTitleAndDistrict(title, districtId, page);
+    }
+
+    /*
+    게시글 리스트 제목 + 카테고리 + 지역으로 검색
+     */
+    @GetMapping("/board/search-title-category-district/{categoryId}/{districtId}/{page}")
+    public ResponseEntity<?> boardListInquiryByTitleAndCategoryAndDistrict(@RequestParam(name = "title") String title,
+                                                                           @PathVariable int categoryId,
+                                                                           @PathVariable int districtId,
+                                                                           @PathVariable int page) {
+
+        return boardService.boardListInquiryByTitleAndCategoryAndDistrict(title, categoryId, districtId, page);
+    }
 }

--- a/src/main/java/com/example/newfieldpasser/repository/BoardRepository.java
+++ b/src/main/java/com/example/newfieldpasser/repository/BoardRepository.java
@@ -34,4 +34,19 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @EntityGraph(attributePaths = {"member","category","district"})
     Slice<Board> findByCategory_CategoryIdAndDistrict_DistrictId(int categoryId, int districtId, PageRequest pageRequest);
 
+    @EntityGraph(attributePaths = {"member","category","district"})
+    Slice<Board> findByTitleContaining(String title, PageRequest pageRequest);
+
+    @EntityGraph(attributePaths = {"member","category","district"})
+    Slice<Board> findByTitleContainingAndCategory_CategoryId(String title, int categoryId, PageRequest pageRequest);
+
+    @EntityGraph(attributePaths = {"member","category","district"})
+    Slice<Board> findByTitleContainingAndDistrict_DistrictId(String title, int districtId, PageRequest pageRequest);
+
+    @EntityGraph(attributePaths = {"member","category","district"})
+    Slice<Board> findByTitleContainingAndCategory_CategoryIdAndDistrict_DistrictId(String title,
+                                                                                   int categoryId,
+                                                                                   int districtId,
+                                                                                   PageRequest pageRequest);
+
 }

--- a/src/main/java/com/example/newfieldpasser/service/BoardService.java
+++ b/src/main/java/com/example/newfieldpasser/service/BoardService.java
@@ -231,4 +231,84 @@ public class BoardService {
             throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
         }
     }
+
+    /*
+    게시글 리스트 조회 - 제목
+     */
+    public ResponseEntity<?> boardListInquiryByTitle(String title, int page) {
+        try {
+
+            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
+
+            Slice<BoardDTO.boardResDTO> boardList =
+                    boardRepository.findByTitleContaining(title, pageRequest)
+                            .map(BoardDTO.boardResDTO::new);
+
+            return response.success(boardList, "Board Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("게시글 리스트 조회 실패!");
+            throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
+        }
+    }
+
+    /*
+    게시글 리스트 조회 - 제목 + 카테고리
+     */
+    public ResponseEntity<?> boardListInquiryByTitleAndCategory(String title, int categoryId, int page) {
+        try {
+
+            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
+
+            Slice<BoardDTO.boardResDTO> boardList =
+                    boardRepository.findByTitleContainingAndCategory_CategoryId(title,categoryId,pageRequest)
+                            .map(BoardDTO.boardResDTO::new);
+
+            return response.success(boardList, "Board Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("게시글 리스트 조회 실패!");
+            throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
+        }
+    }
+
+    /*
+    게시글 리스트 조회 - 제목 + 지역
+     */
+    public ResponseEntity<?> boardListInquiryByTitleAndDistrict(String title, int districtId, int page) {
+        try {
+
+            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
+
+            Slice<BoardDTO.boardResDTO> boardList =
+                    boardRepository.findByTitleContainingAndDistrict_DistrictId(title,districtId,pageRequest)
+                            .map(BoardDTO.boardResDTO::new);
+
+            return response.success(boardList, "Board Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("게시글 리스트 조회 실패!");
+            throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
+        }
+    }
+
+    /*
+    게시글 리스트 조회 - 제목 + 카테고리 + 지역
+     */
+    public ResponseEntity<?> boardListInquiryByTitleAndCategoryAndDistrict(String title, int categoryId, int districtId, int page) {
+        try {
+
+            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
+
+            Slice<BoardDTO.boardResDTO> boardList =
+                    boardRepository.findByTitleContainingAndCategory_CategoryIdAndDistrict_DistrictId(title, categoryId, districtId, pageRequest)
+                            .map(BoardDTO.boardResDTO::new);
+
+            return response.success(boardList, "Board Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("게시글 리스트 조회 실패!");
+            throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
+        }
+    }
 }


### PR DESCRIPTION
## Motivation

제목으로 게시글 리스트 검색 기능 구현하였습니다.
제목만으로 검색, 제목 + 카테고리로 검색, 제목 + 지역으로 검색, 제목 + 카테고리 + 지역으로 검색
이렇게 네 가지 방법으로 검색할 수 있도록 하였습니다.

## Key Changes

- 제목으로 게시글 리스트 검색
- 제목 + 카테고리로 게시글 리스트 검색
- 제목 + 지역으로 게시글 리스트 검색
- 제목 + 카테고리 + 지역으로 게시글 리스트 검색

## To reviewers

코드 확인 부탁드립니다
