### PR TITLE
feat: 문의글 등록, 리스트 조회, 상세 조회, 수정, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/newfieldpasser/config/SecurityConfig.java
+++ b/src/main/java/com/example/newfieldpasser/config/SecurityConfig.java
@@ -74,6 +74,7 @@ public class SecurityConfig {
                 .authorizeRequests() // '인증'이 필요하다
                 .antMatchers("/board/**").authenticated()// 게시글 관련 인증 필요
                 .antMatchers("/my-page/**").authenticated() // 마이페이지 인증 필요
+                .antMatchers("/question/**").authenticated() // 문의글 관련 인증 필요
                 //.antMatchers("/api/admin/**").hasRole("ADMIN") // 관리자 페이지
                 .anyRequest().permitAll()
 

--- a/src/main/java/com/example/newfieldpasser/controller/QuestionController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/QuestionController.java
@@ -5,9 +5,7 @@ import com.example.newfieldpasser.service.QuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,4 +21,43 @@ public class QuestionController {
 
         return questionService.registerQuestion(authentication, questionReqDTO);
     }
+
+    /*
+    문의글 리스트 조회
+     */
+    @GetMapping("/question/inquiry/{page}")
+    public ResponseEntity<?> questionInquiry(@PathVariable int page,
+                                             Authentication authentication) {
+
+        return questionService.questionInquiry(page, authentication);
+    }
+
+    /*
+    문의글 상세조회
+     */
+    @GetMapping("/question/{questionId}")
+    public ResponseEntity<?> questionDetail(@PathVariable long questionId) {
+
+        return questionService.questionDetail(questionId);
+    }
+
+    /*
+    문의글 수정
+     */
+    @PutMapping("/question/edit/{questionId}")
+    public ResponseEntity<?> editQuestion(@PathVariable long questionId,
+                                            @RequestBody QuestionDTO.QuestionReqDTO questionReqDTO) {
+
+        return questionService.editQuestion(questionId, questionReqDTO);
+    }
+
+    /*
+    문의글 삭제
+     */
+    @DeleteMapping("/question/delete/{questionId}")
+    public ResponseEntity<?> deleteQuestion(@PathVariable long questionId) {
+
+        return questionService.deleteQuestion(questionId);
+    }
+
 }

--- a/src/main/java/com/example/newfieldpasser/controller/QuestionController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/QuestionController.java
@@ -1,0 +1,26 @@
+package com.example.newfieldpasser.controller;
+
+import com.example.newfieldpasser.dto.QuestionDTO;
+import com.example.newfieldpasser.service.QuestionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class QuestionController {
+    private final QuestionService questionService;
+
+    /*
+    문의글 등록
+     */
+    @PostMapping("/question/register")
+    public ResponseEntity<?> registerQuestion(Authentication authentication,
+                                              @RequestBody QuestionDTO.QuestionReqDTO questionReqDTO) {
+
+        return questionService.registerQuestion(authentication, questionReqDTO);
+    }
+}

--- a/src/main/java/com/example/newfieldpasser/dto/QuestionDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/QuestionDTO.java
@@ -4,10 +4,9 @@ import com.example.newfieldpasser.entity.Member;
 import com.example.newfieldpasser.entity.Question;
 import com.example.newfieldpasser.parameter.QuestionCategory;
 import com.example.newfieldpasser.parameter.QuestionProcess;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+
+import java.time.LocalDateTime;
 
 public class QuestionDTO {
 
@@ -29,5 +28,28 @@ public class QuestionDTO {
                     .build();
         }
 
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class QuestionResDTO {
+        private long questionId;
+        private String questionTitle;
+        private String questionContent;
+        private String questionCategory;
+        private String questionProcess;
+        private LocalDateTime questionRegisterDate;
+        private LocalDateTime questionUpdateDate;
+
+        @Builder
+        public QuestionResDTO(Question question) {
+            this.questionId = question.getQuestionId();
+            this.questionTitle = question.getQuestionTitle();
+            this.questionContent = question.getQuestionContent();
+            this.questionCategory = question.getQuestionCategory().getTitle();
+            this.questionProcess = question.getQuestionProcess().getTitle();
+            this.questionRegisterDate = question.getQuestionRegisterDate();
+            this.questionUpdateDate = question.getQuestionUpdateDate();
+        }
     }
 }

--- a/src/main/java/com/example/newfieldpasser/dto/QuestionDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/QuestionDTO.java
@@ -1,0 +1,33 @@
+package com.example.newfieldpasser.dto;
+
+import com.example.newfieldpasser.entity.Member;
+import com.example.newfieldpasser.entity.Question;
+import com.example.newfieldpasser.parameter.QuestionCategory;
+import com.example.newfieldpasser.parameter.QuestionProcess;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class QuestionDTO {
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class QuestionReqDTO {
+        private String questionTitle;
+        private String questionContent;
+        private QuestionCategory questionCategory;
+        private final QuestionProcess questionProcess = QuestionProcess.BEFORE_ANSWER;
+
+        public Question toEntity(Member member) {
+            return Question.builder()
+                    .member(member)
+                    .questionTitle(questionTitle)
+                    .questionContent(questionContent)
+                    .questionCategory(questionCategory)
+                    .questionProcess(questionProcess)
+                    .build();
+        }
+
+    }
+}

--- a/src/main/java/com/example/newfieldpasser/entity/Question.java
+++ b/src/main/java/com/example/newfieldpasser/entity/Question.java
@@ -2,12 +2,15 @@ package com.example.newfieldpasser.entity;
 
 import com.example.newfieldpasser.parameter.QuestionCategory;
 import com.example.newfieldpasser.parameter.QuestionProcess;
+import com.example.newfieldpasser.parameter.TransactionStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -18,6 +21,8 @@ import java.time.LocalDateTime;
 @Builder
 @Entity
 @Table(name = "question")
+@SQLDelete(sql = "UPDATE question SET question_delete_check = true WHERE question_id = ?")
+@Where(clause = "question_delete_check = false")
 public class Question {
     @Id
     @GeneratedValue
@@ -55,4 +60,12 @@ public class Question {
 
     @Column(name = "question_delete_check")
     private boolean questionDeleteCheck;
+
+    public void updateQuestion(String questionTitle, String questionContent,
+                               QuestionCategory questionCategory, QuestionProcess questionProcess) {
+        this.questionTitle = questionTitle;
+        this.questionContent = questionContent;
+        this.questionCategory = questionCategory;
+        this.questionProcess = questionProcess;
+    }
 }

--- a/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
+++ b/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
@@ -13,7 +13,10 @@ public enum ErrorCode {
     REGISTER_WISH_BOARD_FAIL(HttpStatus.BAD_REQUEST, "Register WishBoard Failed!"),
     WISH_LIST_INQUIRY_FAIL(HttpStatus.BAD_REQUEST, "WishList Inquiry Failed!"),
     WISH_BOARD_DELETE_FAIL(HttpStatus.BAD_REQUEST, "Delete WishBoard Failed!"),
-    REGISTER_QUESTION_FAIL(HttpStatus.BAD_REQUEST, "Register Question Failed!");
+    REGISTER_QUESTION_FAIL(HttpStatus.BAD_REQUEST, "Register Question Failed!"),
+    QUESTION_LIST_INQUIRY_FAIL(HttpStatus.BAD_REQUEST, "QuestionList Inquiry Failed!"),
+    QUESTION_EDIT_FAIL(HttpStatus.BAD_REQUEST, "Question Edit Failed!"),
+    QUESTION_DELETE_FAIL(HttpStatus.BAD_REQUEST, "Board Delete Failed!");
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
+++ b/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     BOARD_LIST_INQUIRY_FAIL(HttpStatus.BAD_REQUEST, "BoardList Inquiry Failed!"),
     REGISTER_WISH_BOARD_FAIL(HttpStatus.BAD_REQUEST, "Register WishBoard Failed!"),
     WISH_LIST_INQUIRY_FAIL(HttpStatus.BAD_REQUEST, "WishList Inquiry Failed!"),
-    WISH_BOARD_DELETE_FAIL(HttpStatus.BAD_REQUEST, "Delete WishBoard Failed!");
+    WISH_BOARD_DELETE_FAIL(HttpStatus.BAD_REQUEST, "Delete WishBoard Failed!"),
+    REGISTER_QUESTION_FAIL(HttpStatus.BAD_REQUEST, "Register Question Failed!");
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/com/example/newfieldpasser/parameter/QuestionCategory.java
+++ b/src/main/java/com/example/newfieldpasser/parameter/QuestionCategory.java
@@ -1,5 +1,14 @@
 package com.example.newfieldpasser.parameter;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum QuestionCategory {
-    거래_관련, 서비스_관련, 계정_관련
+    TRANSACTION("거래 관련"),
+    SERVICE("서비스 관련"),
+    ACCOUNT("계정 관련");
+
+    private final String title;
 }

--- a/src/main/java/com/example/newfieldpasser/parameter/QuestionProcess.java
+++ b/src/main/java/com/example/newfieldpasser/parameter/QuestionProcess.java
@@ -1,5 +1,13 @@
 package com.example.newfieldpasser.parameter;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum QuestionProcess {
-    답변_전, 답변_완료
+    BEFORE_ANSWER("답변 전"),
+    COMPLETE_ANSWER("답변 완료");
+
+    private final String title;
 }

--- a/src/main/java/com/example/newfieldpasser/repository/QuestionRepository.java
+++ b/src/main/java/com/example/newfieldpasser/repository/QuestionRepository.java
@@ -1,0 +1,7 @@
+package com.example.newfieldpasser.repository;
+
+import com.example.newfieldpasser.entity.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}

--- a/src/main/java/com/example/newfieldpasser/repository/QuestionRepository.java
+++ b/src/main/java/com/example/newfieldpasser/repository/QuestionRepository.java
@@ -1,7 +1,19 @@
 package com.example.newfieldpasser.repository;
 
 import com.example.newfieldpasser.entity.Question;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    @EntityGraph(attributePaths = {"member"})
+    Slice<Question> findByMember_MemberId(String memberId , PageRequest pageRequest);
+
+    Optional<Question> findByQuestionId(long questionId);
+
+    void deleteByQuestionId(long questionId);
 }

--- a/src/main/java/com/example/newfieldpasser/service/QuestionService.java
+++ b/src/main/java/com/example/newfieldpasser/service/QuestionService.java
@@ -1,0 +1,44 @@
+package com.example.newfieldpasser.service;
+
+import com.example.newfieldpasser.dto.QuestionDTO;
+import com.example.newfieldpasser.dto.Response;
+import com.example.newfieldpasser.entity.Member;
+import com.example.newfieldpasser.exception.board.BoardException;
+import com.example.newfieldpasser.exception.board.ErrorCode;
+import com.example.newfieldpasser.repository.MemberRepository;
+import com.example.newfieldpasser.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuestionService {
+
+    private final MemberRepository memberRepository;
+    private final QuestionRepository questionRepository;
+    private final Response response;
+
+    /*
+    문의글 등록
+     */
+    @Transactional
+    public ResponseEntity<?> registerQuestion(Authentication authentication, QuestionDTO.QuestionReqDTO questionReqDTO) {
+        try {
+            String memberId = authentication.getName();
+            Member member = memberRepository.findByMemberId(memberId).get();
+
+            questionRepository.save(questionReqDTO.toEntity(member));
+
+            return response.success("Register Question Success!");
+
+        } catch (BoardException e) {
+            log.error("문의글 등록 실패!");
+            throw new BoardException(ErrorCode.REGISTER_QUESTION_FAIL);
+        }
+    }
+}

--- a/src/main/java/com/example/newfieldpasser/service/QuestionService.java
+++ b/src/main/java/com/example/newfieldpasser/service/QuestionService.java
@@ -3,16 +3,23 @@ package com.example.newfieldpasser.service;
 import com.example.newfieldpasser.dto.QuestionDTO;
 import com.example.newfieldpasser.dto.Response;
 import com.example.newfieldpasser.entity.Member;
+import com.example.newfieldpasser.entity.Question;
 import com.example.newfieldpasser.exception.board.BoardException;
 import com.example.newfieldpasser.exception.board.ErrorCode;
 import com.example.newfieldpasser.repository.MemberRepository;
 import com.example.newfieldpasser.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -41,4 +48,73 @@ public class QuestionService {
             throw new BoardException(ErrorCode.REGISTER_QUESTION_FAIL);
         }
     }
+
+    /*
+    문의글 리스트 조회
+     */
+    public ResponseEntity<?> questionInquiry(int page, Authentication authentication) {
+        try {
+            String memberId = authentication.getName();
+            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "questionRegisterDate"));
+
+            Slice<QuestionDTO.QuestionResDTO> result = questionRepository.findByMember_MemberId(memberId, pageRequest).map(QuestionDTO.QuestionResDTO::new);
+
+            return response.success(result, "Question Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("문의글 조회 실패!");
+            throw new BoardException(ErrorCode.QUESTION_LIST_INQUIRY_FAIL);
+        }
+    }
+
+    /*
+    문의글 상세조회
+     */
+    public ResponseEntity<?> questionDetail(long questionId) {
+        try {
+            QuestionDTO.QuestionResDTO result = questionRepository.findByQuestionId(questionId).map(QuestionDTO.QuestionResDTO::new).get();
+
+            return response.success(result, "Question Detail Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("문의글 조회 실패!");
+            throw new BoardException(ErrorCode.QUESTION_LIST_INQUIRY_FAIL);
+        }
+    }
+
+    /*
+    문의글 수정
+     */
+    @Transactional
+    public ResponseEntity<?> editQuestion(long questionId, QuestionDTO.QuestionReqDTO questionReqDTO) {
+        try {
+            Question findQuestion = questionRepository.findByQuestionId(questionId).get();
+
+            findQuestion.updateQuestion(questionReqDTO.getQuestionTitle(), questionReqDTO.getQuestionContent(),
+                                        questionReqDTO.getQuestionCategory(), questionReqDTO.getQuestionProcess());
+
+            return response.success("Edit Question Success!");
+
+        } catch (BoardException e) {
+            log.error("문의글 수정 실패!");
+            throw new BoardException(ErrorCode.QUESTION_EDIT_FAIL);
+        }
+    }
+
+    /*
+    문의글 삭제
+     */
+    @Transactional
+    public ResponseEntity<?> deleteQuestion(long questionId) {
+        try {
+            questionRepository.deleteByQuestionId(questionId);
+
+            return response.success("Delete Question Success!");
+
+        } catch (BoardException e) {
+            log.error("문의글 삭제 실패!");
+            throw new BoardException(ErrorCode.QUESTION_DELETE_FAIL);
+        }
+    }
+
 }


### PR DESCRIPTION
## Motivation

문의글 등록, 리스트 조회, 상세 조회, 수정, 삭제 기능 구현하였습니다.

문의글 카테고리 ENUM 이렇게 구성했습니다.
TRANSACTION("거래 관련")
SERVICE("서비스 관련")
ACCOUNT("계정 관련")

삭제 기능은 Soft delete로 처리했습니다.

## Key Changes

- 문의글 등록 기능 구현
- 문의글 리스트 조회 기능 구현
- 문의글 상세조회 기능 구현
- 문의글 수정 기능 구현
- 문의글 삭제 기능 구현

## To reviewers

코드 확인부탁드립니다