### PR TITLE
feat: 관리자 승격, 사용자로 전환, 문의글 답변 등록, 문의글 전체 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/newfieldpasser/config/SecurityConfig.java
+++ b/src/main/java/com/example/newfieldpasser/config/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
                 .antMatchers("/board/**").authenticated()// 게시글 관련 인증 필요
                 .antMatchers("/my-page/**").authenticated() // 마이페이지 인증 필요
                 .antMatchers("/question/**").authenticated() // 문의글 관련 인증 필요
-                //.antMatchers("/api/admin/**").hasRole("ADMIN") // 관리자 페이지
+                .antMatchers("/admin/**").hasRole("ADMIN") // 관리자 페이지
                 .anyRequest().permitAll()
 
                 .and()

--- a/src/main/java/com/example/newfieldpasser/controller/AdminController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/AdminController.java
@@ -1,0 +1,33 @@
+package com.example.newfieldpasser.controller;
+
+import com.example.newfieldpasser.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminController { //관리자 승격, 답변 등록 등 관리자 관련 기능들만, 관리자만 할 수 있음
+
+    private final MemberService memberService;
+
+    /*
+    관리자 승격
+     */
+    @PutMapping("/admin/promote")
+    public ResponseEntity<?> promoteAdmin(@RequestParam(name = "memberId") String memberId) {
+
+        return memberService.promoteAdmin(memberId);
+    }
+
+    /*
+    사용자로 전환
+     */
+    @PutMapping("/admin/demote")
+    public ResponseEntity<?> demoteUser(@RequestParam(name = "memberId") String memberId) {
+
+        return memberService.demoteUser(memberId);
+    }
+}

--- a/src/main/java/com/example/newfieldpasser/controller/AdminController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/AdminController.java
@@ -1,17 +1,21 @@
 package com.example.newfieldpasser.controller;
 
+import com.example.newfieldpasser.dto.AnswerDTO;
+import com.example.newfieldpasser.service.AnswerService;
 import com.example.newfieldpasser.service.MemberService;
+import com.example.newfieldpasser.service.QuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 public class AdminController { //관리자 승격, 답변 등록 등 관리자 관련 기능들만, 관리자만 할 수 있음
 
     private final MemberService memberService;
+    private final AnswerService answerService;
+    private final QuestionService questionService;
 
     /*
     관리자 승격
@@ -29,5 +33,25 @@ public class AdminController { //관리자 승격, 답변 등록 등 관리자 �
     public ResponseEntity<?> demoteUser(@RequestParam(name = "memberId") String memberId) {
 
         return memberService.demoteUser(memberId);
+    }
+
+    /*
+    문의글에 대한 답변 등록
+     */
+    @PostMapping("/admin/answer/register")
+    public ResponseEntity<?> registerAnswer(Authentication authentication,
+                                            @RequestParam(name = "questionId") long questionId,
+                                            @RequestBody AnswerDTO.AnswerReqDTO answerReqDTO) {
+
+        return answerService.registerAnswer(authentication, questionId, answerReqDTO);
+    }
+
+    /*
+    문의글 전체조회
+     */
+    @GetMapping("/admin/question-list/{page}")
+    public ResponseEntity<?> inquiryAllQuestion(@PathVariable int page) {
+
+        return questionService.inquiryAllQuestion(page);
     }
 }

--- a/src/main/java/com/example/newfieldpasser/dto/AnswerDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/AnswerDTO.java
@@ -1,0 +1,26 @@
+package com.example.newfieldpasser.dto;
+
+import com.example.newfieldpasser.entity.Answer;
+import com.example.newfieldpasser.entity.Member;
+import com.example.newfieldpasser.entity.Question;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AnswerDTO {
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class AnswerReqDTO {
+        private String answerTitle;
+        private String answerContent;
+
+        public Answer toEntity(Member member) {
+            return Answer.builder()
+                    .member(member)
+                    .answerTitle(answerTitle)
+                    .answerContent(answerContent)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/newfieldpasser/entity/Answer.java
+++ b/src/main/java/com/example/newfieldpasser/entity/Answer.java
@@ -25,10 +25,6 @@ public class Answer {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id")
-    private Question question;
-
     @Column(name = "answer_title")
     private String answerTitle;
 

--- a/src/main/java/com/example/newfieldpasser/entity/Member.java
+++ b/src/main/java/com/example/newfieldpasser/entity/Member.java
@@ -96,5 +96,11 @@ public class Member {
         this.password = password;
     }
 
+    public void promoteAdmin() {
+        this.role = Role.ADMIN;
+    }
 
+    public void changeUser() {
+        this.role = Role.USER;
+    }
 }

--- a/src/main/java/com/example/newfieldpasser/entity/Question.java
+++ b/src/main/java/com/example/newfieldpasser/entity/Question.java
@@ -33,7 +33,8 @@ public class Question {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToOne(mappedBy = "question")
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answer_id")
     private Answer answer;
 
     @Column(name = "question_title")
@@ -67,5 +68,13 @@ public class Question {
         this.questionContent = questionContent;
         this.questionCategory = questionCategory;
         this.questionProcess = questionProcess;
+    }
+
+    public void updateQuestionProcess() {
+        this.questionProcess = QuestionProcess.COMPLETE_ANSWER;
+    }
+
+    public void registerAnswer(Answer answer) {
+        this.answer = answer;
     }
 }

--- a/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
+++ b/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
@@ -16,7 +16,9 @@ public enum ErrorCode {
     REGISTER_QUESTION_FAIL(HttpStatus.BAD_REQUEST, "Register Question Failed!"),
     QUESTION_LIST_INQUIRY_FAIL(HttpStatus.BAD_REQUEST, "QuestionList Inquiry Failed!"),
     QUESTION_EDIT_FAIL(HttpStatus.BAD_REQUEST, "Question Edit Failed!"),
-    QUESTION_DELETE_FAIL(HttpStatus.BAD_REQUEST, "Board Delete Failed!");
+    QUESTION_DELETE_FAIL(HttpStatus.BAD_REQUEST, "Board Delete Failed!"),
+    REGISTER_ANSWER_FAIL(HttpStatus.BAD_REQUEST, "Register Answer Failed!"),
+    ALREADY_EXIST_ANSWER(HttpStatus.CONFLICT, "Already Exist Answer!");
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/com/example/newfieldpasser/exception/member/ErrorCode.java
+++ b/src/main/java/com/example/newfieldpasser/exception/member/ErrorCode.java
@@ -10,10 +10,8 @@ public enum ErrorCode {
 
     SIGNUP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Requested Signup Failed"),
     UPDATE_FAIL(HttpStatus.BAD_REQUEST,"Update Failed"),
-
     DELETE_FAIL(HttpStatus.BAD_REQUEST,"Delete Failed"),
-
-    SEND_EMAIL_FAIL(HttpStatus.BAD_REQUEST,"Sned Email failed"),
+    SEND_EMAIL_FAIL(HttpStatus.BAD_REQUEST,"Send Email failed"),
     ALREADY_EXIST(HttpStatus.CONFLICT, "Already Registered Email");
 
 

--- a/src/main/java/com/example/newfieldpasser/repository/AnswerRepository.java
+++ b/src/main/java/com/example/newfieldpasser/repository/AnswerRepository.java
@@ -1,0 +1,7 @@
+package com.example.newfieldpasser.repository;
+
+import com.example.newfieldpasser.entity.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+}

--- a/src/main/java/com/example/newfieldpasser/repository/QuestionRepository.java
+++ b/src/main/java/com/example/newfieldpasser/repository/QuestionRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -16,4 +17,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     Optional<Question> findByQuestionId(long questionId);
 
     void deleteByQuestionId(long questionId);
+
+    @Query("select p from Question p")
+    Slice<Question> findDefaultAll(PageRequest pageRequest);
 }

--- a/src/main/java/com/example/newfieldpasser/service/AnswerService.java
+++ b/src/main/java/com/example/newfieldpasser/service/AnswerService.java
@@ -1,0 +1,69 @@
+package com.example.newfieldpasser.service;
+
+import com.example.newfieldpasser.dto.AnswerDTO;
+import com.example.newfieldpasser.dto.Response;
+import com.example.newfieldpasser.entity.Answer;
+import com.example.newfieldpasser.entity.Member;
+import com.example.newfieldpasser.entity.Question;
+import com.example.newfieldpasser.exception.board.BoardException;
+import com.example.newfieldpasser.exception.board.ErrorCode;
+import com.example.newfieldpasser.parameter.QuestionProcess;
+import com.example.newfieldpasser.parameter.Role;
+import com.example.newfieldpasser.repository.AnswerRepository;
+import com.example.newfieldpasser.repository.MemberRepository;
+import com.example.newfieldpasser.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnswerService {
+    private final AnswerRepository answerRepository;
+    private final MemberRepository memberRepository;
+    private final QuestionRepository questionRepository;
+    private final Response response;
+
+    /*
+    답변 등록
+     */
+    @Transactional
+    public ResponseEntity<?> registerAnswer(Authentication authentication,
+                                            long questionId,
+                                            AnswerDTO.AnswerReqDTO answerReqDTO) {
+        try {
+            String adminId = authentication.getName();
+            Member member = memberRepository.findByMemberId(adminId).get();
+            Question question = questionRepository.findByQuestionId(questionId).get();
+
+            // 답변 생성
+            Answer answer = answerReqDTO.toEntity(member);
+
+            if (question.getQuestionProcess() == QuestionProcess.BEFORE_ANSWER) { //해당 질문의 답변이 완료되지 않았을 경우에만 답변 등록
+                answerRepository.save(answer);
+            } else {
+                log.error("이미 답변이 등록되었습니다.");
+                throw new BoardException(ErrorCode.ALREADY_EXIST_ANSWER);
+            }
+
+            // 질문 테이블에 답변 외래키 입력
+            question.registerAnswer(answer);
+            // 답변 완료된 질문은 답변 완료 처리
+            question.updateQuestionProcess();
+
+            return response.success("Register Answer Success");
+
+        } catch (BoardException e) {
+            log.error("답변 등록 실패!");
+            throw new BoardException(ErrorCode.REGISTER_ANSWER_FAIL);
+        }
+
+    }
+
+
+}

--- a/src/main/java/com/example/newfieldpasser/service/MemberService.java
+++ b/src/main/java/com/example/newfieldpasser/service/MemberService.java
@@ -150,7 +150,7 @@ public class MemberService {
 
         if(member.getMemberId() == null){
             log.info("해당 이메일이 없습니다 ");
-        }else {
+        } else {
             String encryptPassword = encoder.encode(tmpPassword);
             member.updatePassword(encryptPassword);
             log.info("임시 비밀번호 업데이트");
@@ -167,7 +167,7 @@ public class MemberService {
         if(member != null){
             member.editPassword(encoder.encode(passwordDTO.getPassword()));
             return response.success("비밀번호 변경 성공하셨습니다");
-        }else{
+        } else {
             return response.fail("비밀번호 변경을 할 수 없습니다");
         }
 
@@ -185,19 +185,17 @@ public class MemberService {
             memberRepository.deleteByMemberId(member.getMemberId());
 
             return response.success("Delete Member success");
-        }catch(MemberException e){
+
+        } catch(MemberException e) {
             e.printStackTrace();
             throw new MemberException(ErrorCode.DELETE_FAIL);
         }
 
     }
 
-
     /*
     이메일 인증
     */
-
-
 /*    public ResponseEntity<?> emailAuthentication(AuthDTO.SignupDto signupDto){
         try{
             log.info("이메일 : "+ signupDto.getMemberId());
@@ -216,22 +214,51 @@ public class MemberService {
     }*/
 
 
-
-
-
     /*
       이메일 중복검사
     */
-
     public ResponseEntity<?> dupeEmailCheck(AuthDTO.SignupDto signupDto){
-
-
             if(memberRepository.existsById(signupDto.getMemberId())) {
                 return response.fail(String.format("%s : %s", ErrorCode.ALREADY_EXIST.getMessage(), signupDto.getMemberId()),
                         ErrorCode.ALREADY_EXIST.getStatus());
-            }else{
-
+            } else {
                 return response.success("사용가능한 이메일 입니다");
             }
+    }
+
+    /*
+    관리자 승격
+     */
+    @Transactional
+    public ResponseEntity<?> promoteAdmin(String memberId) {
+        try {
+
+            Member member = memberRepository.findByMemberId(memberId).get();
+            member.promoteAdmin();
+
+            return response.success("Promote Admin Success!");
+
+        } catch (MemberException e) {
+            log.error("관리자 승격 실패!");
+            throw new MemberException(ErrorCode.UPDATE_FAIL);
+        }
+    }
+
+    /*
+    사용자로 전환
+     */
+    @Transactional
+    public ResponseEntity<?> demoteUser(String memberId) {
+        try {
+
+            Member member = memberRepository.findByMemberId(memberId).get();
+            member.changeUser();
+
+            return response.success("Change User Success!");
+
+        } catch (MemberException e) {
+            log.error("관리자 승격 실패!");
+            throw new MemberException(ErrorCode.UPDATE_FAIL);
+        }
     }
 }

--- a/src/main/java/com/example/newfieldpasser/service/QuestionService.java
+++ b/src/main/java/com/example/newfieldpasser/service/QuestionService.java
@@ -117,4 +117,17 @@ public class QuestionService {
         }
     }
 
+    public ResponseEntity<?> inquiryAllQuestion(int page) {
+        try {
+            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "questionRegisterDate"));
+            Slice<QuestionDTO.QuestionResDTO> result = questionRepository.findDefaultAll(pageRequest).map(QuestionDTO.QuestionResDTO::new);
+
+            return response.success(result, "All Question List Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("문의글 조회 실패!");
+            throw new BoardException(ErrorCode.QUESTION_LIST_INQUIRY_FAIL);
+        }
+    }
+
 }


### PR DESCRIPTION
## Motivation

시큐리티 관련 설정 추가 -> /admin/**은 관리자만 접근가능

관리자 승격, 사용자로 전환 기능 구현

문의글 전체 조회 기능 구현 중 N+1 문제 발생
질문 테이블과 답변 테이블을 1대1 관계에서 양방향 관계(대상 테이블에 외래 키가 있는 경우)로 맺음
이를 해결하기 위해 외래키가 질문 테이블(주 테이블)에 있는 단방향 관계로 변경하여 N+1문제 해결

연관관계를 변경하여 문의글 답변 등록 시 -> 질문 테이블에 외래키를 등록 시켜줌
추가로 문의글 답변 등록 시 질문 테이블의 답변 상태를 답변 완료로 변경

답변 완료되어 있는 질문은 중복 답변 등록 불가

## Key Changes

- 관리자 승격
- 사용자 전환
- 문의글 답변 등록
- 문의글 전체 조회

## To reviewers

코드 확인부탁드립니다.