### PR TITLE
feat: 문의글 답변 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/newfieldpasser/controller/QuestionController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/QuestionController.java
@@ -60,4 +60,13 @@ public class QuestionController {
         return questionService.deleteQuestion(questionId);
     }
 
+    /*
+    문의글 답변 조회
+     */
+    @GetMapping("/question/answer/{questionId}")
+    public ResponseEntity<?> inquiryAnswer(@PathVariable long questionId) {
+
+        return questionService.inquiryAnswer(questionId);
+    }
+
 }

--- a/src/main/java/com/example/newfieldpasser/dto/AnswerDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/AnswerDTO.java
@@ -2,10 +2,12 @@ package com.example.newfieldpasser.dto;
 
 import com.example.newfieldpasser.entity.Answer;
 import com.example.newfieldpasser.entity.Member;
-import com.example.newfieldpasser.entity.Question;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 public class AnswerDTO {
 
@@ -21,6 +23,23 @@ public class AnswerDTO {
                     .answerTitle(answerTitle)
                     .answerContent(answerContent)
                     .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class AnswerResDTO {
+        private String answerTitle;
+        private String answerContent;
+        private String memberName;
+        private LocalDateTime answerRegisterDate;
+
+        @Builder
+        public AnswerResDTO(Answer answer) {
+            this.answerTitle = answer.getAnswerTitle();
+            this.answerContent = answer.getAnswerContent();
+            this.memberName = answer.getMember().getMemberName();
+            this.answerRegisterDate = answer.getAnswerRegisterDate();
         }
     }
 }

--- a/src/main/java/com/example/newfieldpasser/dto/QuestionDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/QuestionDTO.java
@@ -4,6 +4,7 @@ import com.example.newfieldpasser.entity.Member;
 import com.example.newfieldpasser.entity.Question;
 import com.example.newfieldpasser.parameter.QuestionCategory;
 import com.example.newfieldpasser.parameter.QuestionProcess;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -40,6 +41,7 @@ public class QuestionDTO {
         private String questionProcess;
         private LocalDateTime questionRegisterDate;
         private LocalDateTime questionUpdateDate;
+        private long answerId;
 
         @Builder
         public QuestionResDTO(Question question) {
@@ -50,6 +52,7 @@ public class QuestionDTO {
             this.questionProcess = question.getQuestionProcess().getTitle();
             this.questionRegisterDate = question.getQuestionRegisterDate();
             this.questionUpdateDate = question.getQuestionUpdateDate();
+            this.answerId = (question.getAnswer() == null) ? 0 : question.getAnswer().getAnswerId(); //NPE 방지 외래키 NULL일 경우 0 반환
         }
     }
 }

--- a/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
+++ b/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
@@ -18,7 +18,8 @@ public enum ErrorCode {
     QUESTION_EDIT_FAIL(HttpStatus.BAD_REQUEST, "Question Edit Failed!"),
     QUESTION_DELETE_FAIL(HttpStatus.BAD_REQUEST, "Board Delete Failed!"),
     REGISTER_ANSWER_FAIL(HttpStatus.BAD_REQUEST, "Register Answer Failed!"),
-    ALREADY_EXIST_ANSWER(HttpStatus.CONFLICT, "Already Exist Answer!");
+    ALREADY_EXIST_ANSWER(HttpStatus.CONFLICT, "Already Exist Answer!"),
+    ANSWER_INQUIRY_FAIL(HttpStatus.BAD_REQUEST, "Answer Inquiry Failed!");
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/com/example/newfieldpasser/repository/AnswerRepository.java
+++ b/src/main/java/com/example/newfieldpasser/repository/AnswerRepository.java
@@ -1,7 +1,13 @@
 package com.example.newfieldpasser.repository;
 
 import com.example.newfieldpasser.entity.Answer;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+    @EntityGraph(attributePaths = {"member"})
+    Optional<Answer> findByAnswerId(long answerId);
 }

--- a/src/main/java/com/example/newfieldpasser/service/QuestionService.java
+++ b/src/main/java/com/example/newfieldpasser/service/QuestionService.java
@@ -1,11 +1,14 @@
 package com.example.newfieldpasser.service;
 
+import com.example.newfieldpasser.dto.AnswerDTO;
 import com.example.newfieldpasser.dto.QuestionDTO;
 import com.example.newfieldpasser.dto.Response;
+import com.example.newfieldpasser.entity.Answer;
 import com.example.newfieldpasser.entity.Member;
 import com.example.newfieldpasser.entity.Question;
 import com.example.newfieldpasser.exception.board.BoardException;
 import com.example.newfieldpasser.exception.board.ErrorCode;
+import com.example.newfieldpasser.repository.AnswerRepository;
 import com.example.newfieldpasser.repository.MemberRepository;
 import com.example.newfieldpasser.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +21,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -28,6 +29,7 @@ public class QuestionService {
 
     private final MemberRepository memberRepository;
     private final QuestionRepository questionRepository;
+    private final AnswerRepository answerRepository;
     private final Response response;
 
     /*
@@ -117,6 +119,9 @@ public class QuestionService {
         }
     }
 
+    /*
+    문의글 전체 조회 (관리자용)
+     */
     public ResponseEntity<?> inquiryAllQuestion(int page) {
         try {
             PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "questionRegisterDate"));
@@ -127,6 +132,25 @@ public class QuestionService {
         } catch (BoardException e) {
             log.error("문의글 조회 실패!");
             throw new BoardException(ErrorCode.QUESTION_LIST_INQUIRY_FAIL);
+        }
+    }
+
+    /*
+    문의글 답변 조회
+     */
+    public ResponseEntity<?> inquiryAnswer(long questionId) {
+        try {
+            // 해당 문의글을 찾고, 답변 기본키 찾아옴
+            Question question = questionRepository.findByQuestionId(questionId).get();
+            long answerId = question.getAnswer().getAnswerId();
+
+            AnswerDTO.AnswerResDTO result = answerRepository.findByAnswerId(answerId).map(AnswerDTO.AnswerResDTO::new).get();
+
+            return response.success(result, "Answer Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("문의글 답변 조회 실패!");
+            throw new BoardException(ErrorCode.ANSWER_INQUIRY_FAIL);
         }
     }
 


### PR DESCRIPTION
## Motivation

문의글에 대한 답변을 조회하는 기능 구현하였습니다.
문의와 답변이 1대1 단방향 연관관계로 문의글을 통해 답변을 조회할 수 있도록 했습니다.
문의글 상세조회 시 answerId가 반환되도록 변경하였습니다.
이 과정에서 답변이 등록되어있지 않을 시에 answerId가 NULL이기 때문에 NPE 방지를 위해 NULL일 경우 0을 반환하도록 했습니다.
답변이 등록되어 NULL이 아닐 경우에는 해당 답변의 answerId를 반환합니다. 

## Key Changes

- 문의글 답변 조회 기능 구현
- 문의글 응답 DTO에 answerId 추가 (NULL일 경우 0 반환)

## To reviewers

코드 확인 부탁드립니다.
