### PR TITLE
feat: 날짜 관련 게시글 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/newfieldpasser/controller/BoardController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/BoardController.java
@@ -8,6 +8,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
+
 @RestController
 @RequiredArgsConstructor
 public class BoardController {
@@ -138,5 +140,57 @@ public class BoardController {
                                                                            @PathVariable int page) {
 
         return boardService.boardListInquiryByTitleAndCategoryAndDistrict(title, categoryId, districtId, page);
+    }
+
+    /*
+    게시글 리스트 날짜 + 제목 + 카테고리 + 지역으로 검색
+     */
+    @GetMapping("/board/date/search-title-category-district/{categoryId}/{districtId}/{page}")
+    public ResponseEntity<?> boardListInquiryByDateAndTitleAndCategoryAndDistrict(@RequestParam(name = "title") String title,
+                                                                                  @RequestParam(name = "startTime") String startTime,
+                                                                                  @RequestParam(name = "endTime") String endTime,
+                                                                                  @PathVariable int categoryId,
+                                                                                  @PathVariable int districtId,
+                                                                                  @PathVariable int page) {
+
+        return boardService.boardListInquiryByDateAndTitleAndCategoryAndDistrict(title,startTime,endTime,categoryId,districtId,page);
+    }
+
+    /*
+    게시글 리스트 날짜 + 제목 + 카테고리로 검색
+     */
+    @GetMapping("/board/date/search-title-category/{categoryId}/{page}")
+    public ResponseEntity<?> boardListInquiryByDateAndTitleAndCategory(@RequestParam(name = "title") String title,
+                                                                       @RequestParam(name = "startTime") String startTime,
+                                                                       @RequestParam(name = "endTime") String endTime,
+                                                                       @PathVariable int categoryId,
+                                                                       @PathVariable int page) {
+
+        return boardService.boardListInquiryByDateAndTitleAndCategory(title,startTime,endTime,categoryId,page);
+    }
+
+    /*
+    게시글 리스트 날짜 + 제목 + 카테고리로 검색
+     */
+    @GetMapping("/board/date/search-title-district/{districtId}/{page}")
+    public ResponseEntity<?> boardListInquiryByDateAndTitleAndDistrict(@RequestParam(name = "title") String title,
+                                                                       @RequestParam(name = "startTime") String startTime,
+                                                                       @RequestParam(name = "endTime") String endTime,
+                                                                       @PathVariable int districtId,
+                                                                       @PathVariable int page) {
+
+        return boardService.boardListInquiryByDateAndTitleAndDistrict(title,startTime,endTime,districtId,page);
+    }
+
+    /*
+    게시글 리스트 날짜 + 제목으로 검색
+     */
+    @GetMapping("/board/date/search-title/{page}")
+    public ResponseEntity<?> boardListInquiryByDateAndTitle(@RequestParam(name = "title") String title,
+                                                            @RequestParam(name = "startTime") String startTime,
+                                                            @RequestParam(name = "endTime") String endTime,
+                                                            @PathVariable int page) {
+
+        return boardService.boardListInquiryByDateAndTitle(title,startTime,endTime,page);
     }
 }

--- a/src/main/java/com/example/newfieldpasser/repository/BoardRepository.java
+++ b/src/main/java/com/example/newfieldpasser/repository/BoardRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
@@ -48,6 +49,45 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
                                                                                    int categoryId,
                                                                                    int districtId,
                                                                                    PageRequest pageRequest);
+
+    @EntityGraph(attributePaths = {"member","category","district"})
+    @Query("select b from Board b " +
+            "where b.title like %:title% " +
+            "and b.category.categoryId = :categoryId " +
+            "and b.district.districtId = :districtId " +
+            "and b.startTime between :startTime and :endTime " +
+            "and b.endTime between :startTime and :endTime")
+    Slice<Board> findByDateAndTitleAndCategoryAndDistrict(@Param("title") String title, @Param("categoryId") int categoryId,
+                                                          @Param("districtId") int districtId, @Param("startTime") LocalDateTime startTime,
+                                                          @Param("endTime") LocalDateTime endTime, PageRequest pageRequest);
+
+    @EntityGraph(attributePaths = {"member","category","district"})
+    @Query("select b from Board b " +
+            "where b.title like %:title% " +
+            "and b.category.categoryId = :categoryId " +
+            "and b.startTime between :startTime and :endTime " +
+            "and b.endTime between :startTime and :endTime")
+    Slice<Board> findByDateAndTitleAndCategory(@Param("title") String title, @Param("categoryId") int categoryId,
+                                               @Param("startTime") LocalDateTime startTime,
+                                               @Param("endTime") LocalDateTime endTime, PageRequest pageRequest);
+
+    @EntityGraph(attributePaths = {"member","category","district"})
+    @Query("select b from Board b " +
+            "where b.title like %:title% " +
+            "and b.district.districtId = :districtId " +
+            "and b.startTime between :startTime and :endTime " +
+            "and b.endTime between :startTime and :endTime")
+    Slice<Board> findByDateAndTitleAndDistrict(@Param("title") String title, @Param("districtId") int districtId,
+                                               @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime,
+                                               PageRequest pageRequest);
+
+    @EntityGraph(attributePaths = {"member","category","district"})
+    @Query("select b from Board b " +
+            "where b.title like %:title% " +
+            "and b.startTime between :startTime and :endTime " +
+            "and b.endTime between :startTime and :endTime")
+    Slice<Board> findByDateAndTitle(@Param("title") String title, @Param("startTime") LocalDateTime startTime,
+                                               @Param("endTime") LocalDateTime endTime, PageRequest pageRequest);
 
     @Modifying
     @Query("update Board b set b.wishCount = b.wishCount + 1 where b.boardId = :boardId")

--- a/src/main/java/com/example/newfieldpasser/service/BoardService.java
+++ b/src/main/java/com/example/newfieldpasser/service/BoardService.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Slf4j
@@ -302,6 +303,97 @@ public class BoardService {
 
             Slice<BoardDTO.boardResDTO> boardList =
                     boardRepository.findByTitleContainingAndCategory_CategoryIdAndDistrict_DistrictId(title, categoryId, districtId, pageRequest)
+                            .map(BoardDTO.boardResDTO::new);
+
+            return response.success(boardList, "Board Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("게시글 리스트 조회 실패!");
+            throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
+        }
+    }
+
+    /*
+    게시글 리스트 조회 - 날짜 + 제목 + 카테고리 + 지역
+     */
+    public ResponseEntity<?> boardListInquiryByDateAndTitleAndCategoryAndDistrict(String title, String startTime, String endTime,
+                                                                                  int categoryId, int districtId, int page) {
+        try {
+            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
+            LocalDateTime start = LocalDateTime.parse(startTime);
+            LocalDateTime end = LocalDateTime.parse(endTime);
+
+            Slice<BoardDTO.boardResDTO> boardList =
+                    boardRepository
+                            .findByDateAndTitleAndCategoryAndDistrict(title, categoryId, districtId, start, end, pageRequest)
+                            .map(BoardDTO.boardResDTO::new);
+
+            return response.success(boardList, "Board Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("게시글 리스트 조회 실패!");
+            throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
+        }
+    }
+
+    /*
+    게시글 리스트 조회 - 날짜 + 제목 + 카테고리
+     */
+    public ResponseEntity<?> boardListInquiryByDateAndTitleAndCategory(String title, String startTime, String endTime,
+                                                                       int categoryId, int page) {
+        try {
+            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
+            LocalDateTime start = LocalDateTime.parse(startTime);
+            LocalDateTime end = LocalDateTime.parse(endTime);
+
+            Slice<BoardDTO.boardResDTO> boardList =
+                    boardRepository
+                            .findByDateAndTitleAndCategory(title, categoryId, start, end, pageRequest)
+                            .map(BoardDTO.boardResDTO::new);
+
+            return response.success(boardList, "Board Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("게시글 리스트 조회 실패!");
+            throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
+        }
+    }
+
+    /*
+    게시글 리스트 조회 - 날짜 + 제목 + 지역
+     */
+    public ResponseEntity<?> boardListInquiryByDateAndTitleAndDistrict(String title, String startTime, String endTime,
+                                                                       int districtId, int page) {
+        try {
+            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
+            LocalDateTime start = LocalDateTime.parse(startTime);
+            LocalDateTime end = LocalDateTime.parse(endTime);
+
+            Slice<BoardDTO.boardResDTO> boardList =
+                    boardRepository
+                            .findByDateAndTitleAndDistrict(title, districtId, start, end, pageRequest)
+                            .map(BoardDTO.boardResDTO::new);
+
+            return response.success(boardList, "Board Inquiry Success!");
+
+        } catch (BoardException e) {
+            log.error("게시글 리스트 조회 실패!");
+            throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
+        }
+    }
+
+    /*
+    게시글 리스트 조회 - 날짜  + 제목으로 검색
+     */
+    public ResponseEntity<?> boardListInquiryByDateAndTitle(String title, String startTime, String endTime, int page) {
+        try {
+            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
+            LocalDateTime start = LocalDateTime.parse(startTime);
+            LocalDateTime end = LocalDateTime.parse(endTime);
+
+            Slice<BoardDTO.boardResDTO> boardList =
+                    boardRepository
+                            .findByDateAndTitle(title, start, end, pageRequest)
                             .map(BoardDTO.boardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");


### PR DESCRIPTION
## Motivation

양도 시작날짜와 종료날짜를 받아 검색할 수 있는 기능을 구현하였습니다.
날짜 + 제목 + 카테고리 + 지역
날짜 + 제목 + 카테고리
날짜 + 제목 + 지역
날짜 + 제목
일단 이렇게 네가지로 일단 구현하였으며 추가 경우의 수가 필요하다면 추가 구현 예정입니다.
쿼리문 직접 작성하여 구현하였습니다.

추가로 시간 데이터는 "2023-06-28T01:30:00" 이런 식으로 받습니다.

## Key Changes

- 날짜 + 제목 + 카테고리 + 지역으로 게시글 리스트 검색 기능 구현
- 날짜 + 제목 + 카테고리로 게시글 리스트 검색 기능 구현
- 날짜 + 제목 + 지역으로 게시글 리스트 검색 기능 구현
- 날짜 + 제목으로 게시글 리스트 검색 기능 구현

## To reviewers

<!-- 이 PR을 확인할 Code Reviewer에게 남길 메시지
- 객체 연관관계가 잘 고려되었는지를 중점적으로 봐주세요
-->
