### PR TITLE
feat: OAuth2를 사용한 구글 소셜 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 
 	//이메일
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	//OAuth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/newfieldpasser/config/SecurityConfig.java
+++ b/src/main/java/com/example/newfieldpasser/config/SecurityConfig.java
@@ -1,9 +1,8 @@
 package com.example.newfieldpasser.config;
 
-import com.example.newfieldpasser.jwt.JwtAccessDeniedHandler;
-import com.example.newfieldpasser.jwt.JwtAuthenticationEntryPoint;
-import com.example.newfieldpasser.jwt.JwtAuthenticationFilter;
-import com.example.newfieldpasser.jwt.JwtTokenProvider;
+import com.example.newfieldpasser.jwt.*;
+import com.example.newfieldpasser.service.AuthService;
+import com.example.newfieldpasser.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -33,6 +32,8 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final AuthService authService;
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     public BCryptPasswordEncoder encoder() {
@@ -82,7 +83,12 @@ public class SecurityConfig {
 
                 .and()
                 .headers()
-                .frameOptions().sameOrigin();
+                .frameOptions().sameOrigin()
+
+                .and()
+                .oauth2Login(oauth2 -> oauth2.successHandler(new OAuth2MemberSuccessHandler(authService))
+                        .userInfoEndpoint()
+                        .userService(customOAuth2UserService));
 
         return http.build();
     }

--- a/src/main/java/com/example/newfieldpasser/dto/OAuth2CustomUser.java
+++ b/src/main/java/com/example/newfieldpasser/dto/OAuth2CustomUser.java
@@ -1,0 +1,37 @@
+package com.example.newfieldpasser.dto;
+
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.List;
+@AllArgsConstructor
+public class OAuth2CustomUser implements OAuth2User, Serializable {
+
+    private String registrationId;
+    private Map<String, Object> attributes;
+    private List<GrantedAuthority> authorities;
+    private String memberId;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return this.attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return this.authorities;
+    }
+
+    @Override
+    public String getName() {
+        return this.registrationId;
+    }
+
+    public String getMemberId() {
+        return this.memberId;
+    }
+}

--- a/src/main/java/com/example/newfieldpasser/dto/OAuthAttributes.java
+++ b/src/main/java/com/example/newfieldpasser/dto/OAuthAttributes.java
@@ -1,0 +1,79 @@
+package com.example.newfieldpasser.dto;
+
+import com.example.newfieldpasser.entity.Member;
+import com.example.newfieldpasser.parameter.Role;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@ToString
+public class OAuthAttributes {
+    private final Map<String, Object> attributes;     // OAuth2 반환하는 유저 정보
+    private final String nameAttributesKey;
+    private final String name;
+    private final String email;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributesKey, String name, String email) {
+        this.attributes = attributes;
+        this.nameAttributesKey = nameAttributesKey;
+        this.name = name;
+        this.email = email;
+    }
+
+    public static OAuthAttributes of(String socialName, Map<String, Object> attributes) {
+        if ("google".equals(socialName)) {
+            return ofGoogle("sub", attributes);
+        }
+
+        return null;
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .name(String.valueOf(attributes.get("name")))
+                .email(String.valueOf(attributes.get("email")))
+                .attributes(attributes)
+                .nameAttributesKey(userNameAttributeName)
+                .build();
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                .memberName(name)
+                .memberId(email)
+                .memberDelete(false)
+                .memberNickName(randomHangulName())
+                .role(Role.USER)
+                .build();
+    }
+
+    public String randomHangulName() {
+        List<String> nick = Arrays.asList("기분나쁜", "기분좋은", "신바람나는", "상쾌한", "짜릿한", "그리운",
+                "자유로운", "서운한", "울적한", "비참한", "위축되는", "긴장되는", "두려운", "당당한", "배부른", "수줍은", "창피한", "멋있는",
+                "열받은", "심심한", "잘생긴", "이쁜", "시끄러운", "행복한", "희망찬", "우아한", "섬세한", "매혹적인", "화려한", "센스있는",
+                "용감한", "밝은", "사랑스러운", "열정적인", "단순한", "섹시한", "매력적인", "귀여운", "도도한", "친절한", "민첩한", "신비로운",
+                "말랑말랑한", "깔끔한", "청량한", "활기찬", "자상한", "포근한", "천진난만한", "늠름한", "정직한", "활발한", "성실한", "조용한",
+                "유능한", "강인한", "신중한", "열심인", "명랑한", "재미있는", "낭만적인", "소박한", "근엄한", "용감한", "신사적인", "고상한",
+                "고결한", "순수한", "예쁜", "멋진", "유쾌한", "카리스마있는", "긍정적인", "부드러운", "매너있는", "내추럴한", "지적인", "세련된",
+                "극한의", "강렬한", "날카로운", "관능적인", "은은한", "빛나는");
+        List<String> name = Arrays.asList("사자", "코끼리", "호랑이", "곰", "여우", "늑대", "너구리",
+                "침팬치", "고릴라", "참새", "고슴도치", "강아지", "고양이", "거북이", "토끼", "앵무새", "하이에나", "돼지", "하마",
+                "원숭이", "물소", "얼룩말", "치타", "악어", "기린", "수달", "염소", "다람쥐", "판다", "팽귄", "오리", "낙타",
+                "뱀", "두꺼비", "원숭이", "바다사자", "알파카", "캥거루", "북극곰", "순록", "고슴도치", "개미핥기새", "코알라",
+                "하이에나", "기린", "갈매기", "플라밍고", "카멜레온", "매", "캥거루", "말", "낙타", "햄스터", "토끼", "다람쥐",
+                "원숭이", "판다", "물소", "비버", "오소리", "바다사자", "스컹크", "해달", "알파카", "침팬치", "팽귄", "코뿔소",
+                "암모나이트", "스테고사우루스", "벨로포시스", "테리포르마", "디모르포돈", "드래곤", "유니콘", "사이보그", "로봇",
+                "인공지능", "몬스터", "드래곤볼", "스폰지밥", "마리오", "소닉", "배트맨", "슈퍼맨", "아이언맨", "헐크", "스파이더맨");
+        Collections.shuffle(nick);
+        Collections.shuffle(name);
+        return nick.get(0) + name.get(0);
+    }
+
+}

--- a/src/main/java/com/example/newfieldpasser/entity/Member.java
+++ b/src/main/java/com/example/newfieldpasser/entity/Member.java
@@ -66,6 +66,7 @@ public class Member {
 
     @OneToMany(mappedBy = "member")
     private List<Reply> replyList;
+
     // == 생성 메서드 == //
     public static Member registerUser(AuthDTO.SignupDto signupDto) {
         Member member = new Member();
@@ -103,5 +104,11 @@ public class Member {
 
     public void changeUser() {
         this.role = Role.USER;
+    }
+
+    public Member updateName(Member member, String memberName) {
+        member.memberName = memberName;
+
+        return member;
     }
 }

--- a/src/main/java/com/example/newfieldpasser/jwt/OAuth2MemberSuccessHandler.java
+++ b/src/main/java/com/example/newfieldpasser/jwt/OAuth2MemberSuccessHandler.java
@@ -1,0 +1,77 @@
+package com.example.newfieldpasser.jwt;
+
+import com.example.newfieldpasser.dto.AuthDTO;
+import com.example.newfieldpasser.dto.OAuth2CustomUser;
+import com.example.newfieldpasser.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final AuthService authService;
+    private final long COOKIE_EXPIRATION = 7776000;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        OAuth2CustomUser oAuth2User = (OAuth2CustomUser) authentication.getPrincipal();
+
+        String memberId = oAuth2User.getMemberId(); // OAuth2User로부터 Resource Owner의 이메일 주소를 얻음 객체로부터
+        String authorities = oAuth2User.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+        String registrationId = oAuth2User.getName();
+
+        redirect(request, response, memberId, authorities, registrationId);  // Access Token과 Refresh Token을 Frontend에 전달하기 위해 Redirect
+    }
+
+    private void redirect(HttpServletRequest request, HttpServletResponse response, String memberId, String authorities, String registrationId) throws IOException {
+
+        AuthDTO.TokenDto tokenDto = authService.generateToken(registrationId, memberId, authorities);
+
+        // 쿠키에 RT 저장
+        HttpCookie httpCookie = ResponseCookie.from("refresh-token", tokenDto.getRefreshToken())
+                .maxAge(COOKIE_EXPIRATION)
+                .httpOnly(true)
+                .secure(true)
+                .build();
+
+        String AT = tokenDto.getAccessToken();
+        String RT = httpCookie.toString();
+
+        String uri = createURI(AT, RT, memberId);
+        getRedirectStrategy().sendRedirect(request, response, uri); // sendRedirect() 메서드를 이용해 Frontend 애플리케이션 쪽으로 리다이렉트
+    }
+
+    // Redirect URI 생성. JWT를 쿼리 파라미터로 담아 전달한다.
+    private String createURI(String accessToken, String refreshToken, String memberId) {
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add("memberId", memberId);
+        queryParams.add("access_token", accessToken);
+        queryParams.add("refresh_token", refreshToken);
+
+        return UriComponentsBuilder
+                .newInstance()
+                .scheme("https")
+                .host("field-passer.store")
+                .queryParams(queryParams)
+                .build()
+                .toString();
+    }
+}

--- a/src/main/java/com/example/newfieldpasser/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/newfieldpasser/service/CustomOAuth2UserService.java
@@ -1,0 +1,63 @@
+package com.example.newfieldpasser.service;
+
+import com.example.newfieldpasser.dto.OAuth2CustomUser;
+import com.example.newfieldpasser.dto.OAuthAttributes;
+import com.example.newfieldpasser.entity.Member;
+import com.example.newfieldpasser.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final MemberRepository memberRepository;
+
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> service = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = service.loadUser(userRequest);  // OAuth2 정보를 가져옵니다.
+
+        Map<String, Object> originAttributes = oAuth2User.getAttributes();  // OAuth2User의 attribute
+
+        // OAuth2 서비스 id (google, kakao, naver)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId(); // 소셜 정보를 가져옵니다.
+
+        // OAuthAttributes: OAuth2User의 attribute를 서비스 유형에 맞게 담아줄 클래스
+        OAuthAttributes attributes = OAuthAttributes.of(registrationId, originAttributes);
+        Member member = saveOrUpdate(attributes);
+        String memberId = member.getMemberId();
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(() -> member.getRole().getKey());
+
+        return new OAuth2CustomUser(registrationId, originAttributes, authorities, memberId);
+    }
+
+    /**
+     * 이미 존재하는 회원이라면 이름과 프로필이미지를 업데이트해줍니다.
+     * 처음 가입하는 회원이라면 User 테이블을 생성합니다.
+     **/
+    private Member saveOrUpdate(OAuthAttributes authAttributes) {
+        Member member = memberRepository.findByMemberId(authAttributes.getEmail())
+                .map(m -> m.updateName(m, authAttributes.getName()))
+                .orElse(authAttributes.toEntity());
+
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/example/newfieldpasser/service/MemberService.java
+++ b/src/main/java/com/example/newfieldpasser/service/MemberService.java
@@ -240,7 +240,6 @@ public class MemberService {
     }
 
     /*
-<<<<<<< HEAD
     관리자 승격
      */
     @Transactional


### PR DESCRIPTION
## Motivation

OAuth2를 사용한 구글 소셜 로그인 기능 구현하였습니다.
https://field-passer.store/oauth2/authorization/google
위 주소로 연결 시 구글 소셜 로그인 창으로 넘어간 후 로그인 완료되면 쿼리 파라미터로 멤버아이디, AT, RT 반환
회원가입 안되어있을 시 자동 회원가입
자동 닉네임 생성 메서드 추가 -> 소셜 로그인 시 자동으로 닉네임 생성 후 저장

## Key Changes

- 구글 소셜 로그인 기능 구현

## To reviewers

코드 확인부탁드립니다.
