### PR TITLE
refactor: 회원탈퇴 에러 해결 및 조건검색 파라미터로 배열 받는 것으로 변경

### DIFF
--- a/src/main/java/com/example/newfieldpasser/controller/BoardController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/BoardController.java
@@ -253,10 +253,10 @@ public class BoardController {
                                          @RequestParam(name = "categoryName", required = false) String categoryName,
                                          @RequestParam(name = "startTime", required = false, defaultValue = "1900-01-01T00:00:00") String startTime,
                                          @RequestParam(name = "endTime", required = false, defaultValue = "9999-12-31T23:59:59") String endTime,
-                                         @RequestBody DistrictDTO.DistrictReqDTO districtReqDTO,
+                                         @RequestParam(name = "districtIds", required = false) List<Integer> districtIds,
                                          @PathVariable int page) {
 
-        return boardService.searchBoard(title, categoryName, startTime,endTime, districtReqDTO, page);
+        return boardService.searchBoard(title, categoryName, startTime,endTime, districtIds, page);
     }
 
 }

--- a/src/main/java/com/example/newfieldpasser/controller/MemberController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/MemberController.java
@@ -69,9 +69,9 @@ public class MemberController {
 
     @DeleteMapping("/my-page/withdrawal")
     public ResponseEntity<?> deleteMember(Authentication authentication,
-                                          @RequestHeader("Authorization") String requestAccessToken){
+                                          @RequestHeader("Authorization") String requestAccessTokenInHeader){
 
-        return memberService.deleteMember(authentication, requestAccessToken);
+        return memberService.deleteMember(authentication, requestAccessTokenInHeader);
     }
 
     /*

--- a/src/main/java/com/example/newfieldpasser/service/BoardService.java
+++ b/src/main/java/com/example/newfieldpasser/service/BoardService.java
@@ -504,10 +504,9 @@ public class BoardService {
         }
     }
 
-    public ResponseEntity<?> searchBoard(String title, String categoryName, String start, String end, DistrictDTO.DistrictReqDTO districtReqDTO, int page) {
+    public ResponseEntity<?> searchBoard(String title, String categoryName, String start, String end, List<Integer> districtIds, int page) {
 
         try {
-            List<Integer> districtIds = districtReqDTO.getDistrictIds();
             Pageable pageable = PageRequest.of(page - 1, 10);
             LocalDateTime startTime = LocalDateTime.parse(start);
             LocalDateTime endTime = LocalDateTime.parse(end);

--- a/src/main/java/com/example/newfieldpasser/service/MemberService.java
+++ b/src/main/java/com/example/newfieldpasser/service/MemberService.java
@@ -198,12 +198,12 @@ public class MemberService {
     회원탈퇴
     */
     @Transactional
-    public ResponseEntity<?> deleteMember(Authentication authentication, String requestAccessToken){
+    public ResponseEntity<?> deleteMember(Authentication authentication, String requestAccessTokenInHeader){
 
         try{
-
+            String requestAccessToken = resolveToken(requestAccessTokenInHeader);
+            String memberId = authentication.getName();
             Member member = memberRepository.findByMemberId(authentication.getName()).get();
-            String memberId = member.getMemberId();
             memberRepository.deleteByMemberId(memberId);
 
             String provider = member.getMemberProvider() == null ? SERVER : member.getMemberProvider(); //null이면 서버에서 저장 null이 아니면 소셜 로그인
@@ -231,6 +231,16 @@ public class MemberService {
             throw new MemberException(ErrorCode.DELETE_FAIL);
         }
 
+    }
+
+    /*
+     "Bearer {AT}"에서 {AT} 추출
+     */
+    public String resolveToken(String requestAccessTokenInHeader) {
+        if (requestAccessTokenInHeader != null && requestAccessTokenInHeader.startsWith("Bearer ")) {
+            return requestAccessTokenInHeader.substring(7);
+        }
+        return null;
     }
 
     /*


### PR DESCRIPTION
## Motivation

회원탈퇴 시 500에러 나는 현상 수정 (원인 : 헤더에서 토큰 뽑는 과정을 생략하였음)
조건검색 시 body로 배열 값을 받는 것이 아닌 파라미터로 받을 수 있도록 변경

## Key Changes

- 회원탈퇴 에러 해결
- 조건검색 파라미터 수정

## To reviewers

코드 확인해주세요!
