### PR TITLE
feat: 양도시작시간이 지난 게시글 삭제 기능 추가 및 상세조회 응답값 변경, 회원정보 조회 응답값 변경

### DIFF
--- a/src/main/java/com/example/newfieldpasser/NewFieldPasserApplication.java
+++ b/src/main/java/com/example/newfieldpasser/NewFieldPasserApplication.java
@@ -3,12 +3,14 @@ package com.example.newfieldpasser;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import javax.annotation.PostConstruct;
 import java.util.TimeZone;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class NewFieldPasserApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/newfieldpasser/controller/BoardController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/BoardController.java
@@ -32,12 +32,13 @@ public class BoardController {
     /*
     게시글 상세조회
      */
-    @GetMapping("/board/{boardId}")
-    public ResponseEntity<?> boardInquiryDetail(@PathVariable long boardId) {
+    @GetMapping("/detail/{boardId}")
+    public ResponseEntity<?> boardInquiryDetail(@PathVariable long boardId,
+                                                Authentication authentication) {
         // 상세조회 시 조회 수 카운트
         boardService.updateViewCount(boardId);
 
-        return boardService.boardInquiryDetail(boardId);
+        return boardService.boardInquiryDetail(boardId, authentication);
     }
 
     /*

--- a/src/main/java/com/example/newfieldpasser/dto/BoardDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/BoardDTO.java
@@ -90,5 +90,53 @@ public class BoardDTO {
         }
     }
 
+    @Getter
+    @Setter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class boardDetailResDTO {
+        private long boardId;
+        private String memberId;
+        private String memberName;
+        private String categoryName;
+        private String districtName;
+        private String title;
+        private String content;
+        private LocalDateTime registerDate;
+        private LocalDateTime startTime;
+        private LocalDateTime endTime;
+        private String imageUrl;
+        private TransactionStatus transactionStatus;
+        private int price;
+        private String phone;
+        private int viewCount;
+        private int wishCount;
+        private boolean blind;
+        private boolean deleteCheck;
+        private boolean myBoard;
+
+        @Builder
+        public boardDetailResDTO(Board board) {
+            this.boardId = board.getBoardId();
+            this.memberId = board.getMember().getMemberId();
+            this.memberName = board.getMember().getMemberName();
+            this.categoryName = board.getCategory().getCategoryName();
+            this.districtName = board.getDistrict().getDistrictName();
+            this.title = board.getTitle();
+            this.content = board.getContent();
+            this.registerDate = board.getRegisterDate();
+            this.startTime = board.getStartTime();
+            this.endTime = board.getEndTime();
+            this.imageUrl = board.getImageUrl();
+            this.transactionStatus = board.getTransactionStatus();
+            this.price = board.getPrice();
+            this.phone = board.getMember().getMemberPhone();
+            this.viewCount = board.getViewCount();
+            this.wishCount = board.getWishCount();
+            this.blind = board.isBlind();
+            this.deleteCheck = board.isDeleteCheck();
+            this.myBoard = false;
+        }
+    }
+
 
 }

--- a/src/main/java/com/example/newfieldpasser/dto/BoardDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/BoardDTO.java
@@ -51,6 +51,7 @@ public class BoardDTO {
         private long boardId;
         private String memberId;
         private String memberName;
+        private String memberNickName;
         private String categoryName;
         private String districtName;
         private String title;
@@ -72,6 +73,7 @@ public class BoardDTO {
             this.boardId = board.getBoardId();
             this.memberId = board.getMember().getMemberId();
             this.memberName = board.getMember().getMemberName();
+            this.memberNickName = board.getMember().getMemberNickName();
             this.categoryName = board.getCategory().getCategoryName();
             this.districtName = board.getDistrict().getDistrictName();
             this.title = board.getTitle();
@@ -97,6 +99,7 @@ public class BoardDTO {
         private long boardId;
         private String memberId;
         private String memberName;
+        private String memberNickName;
         private String categoryName;
         private String districtName;
         private String title;
@@ -119,6 +122,7 @@ public class BoardDTO {
             this.boardId = board.getBoardId();
             this.memberId = board.getMember().getMemberId();
             this.memberName = board.getMember().getMemberName();
+            this.memberNickName = board.getMember().getMemberNickName();
             this.categoryName = board.getCategory().getCategoryName();
             this.districtName = board.getDistrict().getDistrictName();
             this.title = board.getTitle();

--- a/src/main/java/com/example/newfieldpasser/dto/MypageDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/MypageDTO.java
@@ -1,6 +1,7 @@
 package com.example.newfieldpasser.dto;
 
 import com.example.newfieldpasser.entity.Member;
+import com.example.newfieldpasser.parameter.Role;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,12 +16,14 @@ public class MypageDTO {
         private String memberName;
         private String memberNickName;
         private String memberPhone;
+        private Role role;
 
         public MemberInfo(Member member){
             this.memberId = member.getMemberId();
             this.memberName = member.getMemberName();
             this.memberNickName = member.getMemberNickName();
             this.memberPhone = member.getMemberPhone();
+            this.role = member.getRole();
         }
     }
 

--- a/src/main/java/com/example/newfieldpasser/dto/MypageDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/MypageDTO.java
@@ -16,14 +16,14 @@ public class MypageDTO {
         private String memberName;
         private String memberNickName;
         private String memberPhone;
-        private Role role;
+        private String role;
 
         public MemberInfo(Member member){
             this.memberId = member.getMemberId();
             this.memberName = member.getMemberName();
             this.memberNickName = member.getMemberNickName();
             this.memberPhone = member.getMemberPhone();
-            this.role = member.getRole();
+            this.role = member.getRole().getTitle();
         }
     }
 

--- a/src/main/java/com/example/newfieldpasser/repository/BoardRepository.java
+++ b/src/main/java/com/example/newfieldpasser/repository/BoardRepository.java
@@ -145,4 +145,8 @@ public interface BoardRepository extends JpaRepository<Board, Long>, BoardReposi
     void minusWishCount(@Param("boardId") long boardId);
 
     Slice<Board> findByMember_MemberId(String memberId,PageRequest pageRequest);
+
+    @Modifying
+    @Query("update Board b set b.blind = 1 where b.startTime < :dateTime")
+    void updateTimeOverPost(@Param("dateTime") LocalDateTime dateTime);
 }

--- a/src/main/java/com/example/newfieldpasser/service/BoardService.java
+++ b/src/main/java/com/example/newfieldpasser/service/BoardService.java
@@ -107,9 +107,19 @@ public class BoardService {
     /*
     게시글 상세조회
      */
-    public ResponseEntity<?> boardInquiryDetail(long boardId) {
+    public ResponseEntity<?> boardInquiryDetail(long boardId, Authentication authentication) {
         try {
-            BoardDTO.boardResDTO result = boardRepository.findByBoardId(boardId).map(BoardDTO.boardResDTO::new).get();
+            BoardDTO.boardDetailResDTO result = boardRepository.findByBoardId(boardId).map(BoardDTO.boardDetailResDTO::new).get();
+
+            String loginMemberId = "";
+
+            if (authentication != null) {
+                loginMemberId = authentication.getName();
+            }
+
+            if (loginMemberId.equals(result.getMemberId())) {
+                result.setMyBoard(true);
+            }
 
             return response.success(result, "Board Inquiry Success!");
 

--- a/src/main/java/com/example/newfieldpasser/service/BoardService.java
+++ b/src/main/java/com/example/newfieldpasser/service/BoardService.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -527,5 +528,16 @@ public class BoardService {
             throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
         }
 
+    }
+
+    /*
+    10분마다 양도시간이 지난 게시글들을 확인하여 블라인드 처리함
+     */
+    @Transactional
+    @Scheduled(cron = "0 0/10 * * * *")
+    public void deleteOverTime() {
+
+        LocalDateTime nowDateTime = LocalDateTime.now();
+        boardRepository.updateTimeOverPost(nowDateTime);
     }
 }

--- a/src/main/java/com/example/newfieldpasser/service/BoardService.java
+++ b/src/main/java/com/example/newfieldpasser/service/BoardService.java
@@ -111,11 +111,7 @@ public class BoardService {
         try {
             BoardDTO.boardDetailResDTO result = boardRepository.findByBoardId(boardId).map(BoardDTO.boardDetailResDTO::new).get();
 
-            String loginMemberId = "";
-
-            if (authentication != null) {
-                loginMemberId = authentication.getName();
-            }
+            String loginMemberId = authentication != null ? authentication.getName() : "";
 
             if (loginMemberId.equals(result.getMemberId())) {
                 result.setMyBoard(true);


### PR DESCRIPTION
## Motivation

양도시작시간이 지난 게시글 삭제 기능 추가 및 상세조회 응답값 변경하였습니다.

## Key Changes

- 10분마다 현재시각 기준으로 양도시작시간이 지난 게시글들을 블라인드 처리하도록 하였습니다.
- 프론트 측의 요청으로 게시글 상세조회 시 본인이 작성한 글인지 여부를 추가 반환하도록 변경하였습니다.
- 게시글 상세조회 DTO를 따로 추가 생성하였습니다.
- 상세조회 URL 변경되었습니다. /board/{boardId} ->  /detail/{boardId}
- 게시글 조회 및 상세조회 시 회원 닉네임 추가 반환하도록 변경하였습니다.
- 회원정보 조회 시 관리자 여부 반환하도록 변경하였습니다.

## To reviewers

코드 확인 부탁드립니다!
