### PR TITLE
ref: 댓글 삭제 기능 구현 및 memberEntity reply 삭제 

### DIFF
--- a/src/main/java/com/example/newfieldpasser/entity/Comment.java
+++ b/src/main/java/com/example/newfieldpasser/entity/Comment.java
@@ -18,6 +18,7 @@ import java.util.List;
 @Getter
 @Builder
 @Entity
+@DynamicUpdate
 @Table(name = "comment")
 //@SQLDelete(sql = "UPDATE comment SET comment_delete = true WHERE comment_id =?")
 //@Where(clause = "comment_delete = false")
@@ -43,9 +44,9 @@ public class Comment {
     @OneToMany(mappedBy = "parent",orphanRemoval = true)
     private List<Comment> children = new ArrayList<>();
 
-//
-//    @Column(name="comment_delete")
-//    private Boolean deleteCheck;
+
+    @ColumnDefault("FALSE")
+    private Boolean deleteCheck;
 
     @Column(name = "comment_content", nullable = false)
     private String commentContent;
@@ -59,11 +60,6 @@ public class Comment {
     private LocalDateTime commentUpdateDate;
 
 
-    //    @Formula("(SELECT count(1) FROM reply r WHERE r.comment_Id = comment_Id)")
-//    private int replyCount;
-//
-//    @OneToMany(mappedBy = "comment")
-//    private List<Reply> replyList;
     public void updateComment(String commentContent){
 
         this.commentContent =commentContent;
@@ -74,7 +70,9 @@ public class Comment {
         this.parent = comment;
     }
 
-
+    public void delete(Boolean deleteCheck){
+        this.deleteCheck = deleteCheck;
+    }
 }
 
 

--- a/src/main/java/com/example/newfieldpasser/entity/Member.java
+++ b/src/main/java/com/example/newfieldpasser/entity/Member.java
@@ -67,8 +67,7 @@ public class Member {
     @OneToMany(mappedBy = "member")
     private List<WishBoard> wishBoardList;
 
-    @OneToMany(mappedBy = "member")
-    private List<Reply> replyList;
+ 
 
     // == 생성 메서드 == //
     public static Member registerUser(AuthDTO.SignupDto signupDto) {

--- a/src/main/java/com/example/newfieldpasser/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/example/newfieldpasser/repository/CommentRepositoryCustom.java
@@ -6,7 +6,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CommentRepositoryCustom {
    Slice<CommentDTO.commentResDTO> findByBoardId(Pageable pageable, long boardId);
+
+   Optional<Comment> findCommentByIdWithParent(long commentId);
 }

--- a/src/main/java/com/example/newfieldpasser/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/example/newfieldpasser/repository/CommentRepositoryImpl.java
@@ -9,10 +9,7 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import static com.example.newfieldpasser.entity.QComment.comment;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class CommentRepositoryImpl extends QuerydslRepositorySupport implements CommentRepositoryCustom {
 
@@ -51,5 +48,15 @@ public class CommentRepositoryImpl extends QuerydslRepositorySupport implements 
         }
         });
         return new SliceImpl<>(commentList,pageable,hasNext);
+    }
+
+    @Override
+    public Optional<Comment> findCommentByIdWithParent(long commentId) {
+        Comment selectedComment = queryFactory.select(comment)
+                .from(comment)
+                .leftJoin(comment.parent).fetchJoin()
+                .where(comment.commentId.eq(commentId))
+                .fetchOne();
+        return Optional.ofNullable(selectedComment);
     }
 }


### PR DESCRIPTION
## Motivation

<!-- 작업한 대용에 대한 설명 
- 객체들의 연관관계를 기준으로 Entity를 설계했습니다.
- 도메인 별로 Repository를 생성했습니다.
-->
댓글 삭제 기능을 구현하고 memberEntity reply부분을 삭제했습니다 

## Key Changes

<!-- 작업한 내용의 주요 변경 사항에 대한 나열
  - Post Entity 설계를 완료했습니다.
    - 기간은 Embedded 타입으로 설계했습니다.
  - 변경 2
  - 변경 3
-->


## To reviewers

<!-- 이 PR을 확인할 Code Reviewer에게 남길 메시지
- 객체 연관관계가 잘 고려되었는지를 중점적으로 봐주세요
-->
