### PR TITLE
feat: 관리자용 게시글 블라인드 처리 및 해제 기능 구현, 블라인드 게시글만 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/newfieldpasser/controller/AdminController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.example.newfieldpasser.controller;
 
 import com.example.newfieldpasser.dto.AnswerDTO;
 import com.example.newfieldpasser.service.AnswerService;
+import com.example.newfieldpasser.service.BoardService;
 import com.example.newfieldpasser.service.MemberService;
 import com.example.newfieldpasser.service.QuestionService;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ public class AdminController { //관리자 승격, 답변 등록 등 관리자 �
     private final MemberService memberService;
     private final AnswerService answerService;
     private final QuestionService questionService;
+    private final BoardService boardService;
 
     /*
     관리자 승격
@@ -53,5 +55,23 @@ public class AdminController { //관리자 승격, 답변 등록 등 관리자 �
     public ResponseEntity<?> inquiryAllQuestion(@PathVariable int page) {
 
         return questionService.inquiryAllQuestion(page);
+    }
+
+    /*
+    게시글 블라인드 처리(관리자용)
+     */
+    @PutMapping("/admin/board/blind/{boardId}")
+    public ResponseEntity<?> blindBoard(@PathVariable long boardId) {
+
+        return boardService.blindBoard(boardId);
+    }
+
+    /*
+    블라인드 게시글 조회 (관리자용)
+     */
+    @GetMapping("/admin/board/blind/lookup/{page}")
+    public ResponseEntity<?> blindBoardLookup(@PathVariable int page) {
+
+        return boardService.blindBoardLookup(page);
     }
 }

--- a/src/main/java/com/example/newfieldpasser/entity/Board.java
+++ b/src/main/java/com/example/newfieldpasser/entity/Board.java
@@ -5,15 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.UpdateTimestamp;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -22,6 +21,7 @@ import java.util.List;
 @Getter
 @Builder
 @Entity
+@DynamicUpdate
 @Table(name = "board")
 @SQLDelete(sql = "UPDATE board SET delete_check = true, delete_date = now() WHERE board_id = ?")
 @Where(clause = "delete_check = false AND blind = false")
@@ -113,5 +113,9 @@ public class Board {
         this.endTime = endTime;
         this.transactionStatus = transactionStatus;
         this.price = price;
+    }
+
+    public void blindBoard() {
+        this.blind = !this.blind;
     }
 }

--- a/src/main/java/com/example/newfieldpasser/entity/Member.java
+++ b/src/main/java/com/example/newfieldpasser/entity/Member.java
@@ -21,7 +21,6 @@ import java.util.List;
 @Entity
 @Table(name = "member")
 @SQLDelete(sql = "UPDATE member SET member_delete = true WHERE member_id =?")
-@Where(clause = "member_delete = false")
 public class Member {
     @Id
     @Column(name = "member_id")

--- a/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
+++ b/src/main/java/com/example/newfieldpasser/exception/board/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
     QUESTION_DELETE_FAIL(HttpStatus.BAD_REQUEST, "Board Delete Failed!"),
     REGISTER_ANSWER_FAIL(HttpStatus.BAD_REQUEST, "Register Answer Failed!"),
     ALREADY_EXIST_ANSWER(HttpStatus.CONFLICT, "Already Exist Answer!"),
-    ANSWER_INQUIRY_FAIL(HttpStatus.BAD_REQUEST, "Answer Inquiry Failed!");
+    ANSWER_INQUIRY_FAIL(HttpStatus.BAD_REQUEST, "Answer Inquiry Failed!"),
+    BOARD_BLIND_FAIL(HttpStatus.BAD_REQUEST, "Board Blind Failed!");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/newfieldpasser/repository/BoardRepository.java
+++ b/src/main/java/com/example/newfieldpasser/repository/BoardRepository.java
@@ -19,6 +19,13 @@ public interface BoardRepository extends JpaRepository<Board, Long>, BoardReposi
 
     @EntityGraph(attributePaths = {"member","category","district"})
     Optional<Board> findByBoardId(long boardId);
+
+    @Query(value = "select * from board where board_id = :boardId", nativeQuery = true)
+    Optional<Board> findByBoardIdNative(long boardId);
+
+    @Query(value = "select * from board where blind = true order by register_date DESC", nativeQuery = true)
+    Slice<Board> findBlindBoardNative(PageRequest pageRequest);
+
     @Modifying
     @Query("update Board b set b.viewCount = b.viewCount + 1 where b.boardId = :boardId")
     void updateViewCount(@Param("boardId") long boardId);

--- a/src/main/java/com/example/newfieldpasser/service/BoardService.java
+++ b/src/main/java/com/example/newfieldpasser/service/BoardService.java
@@ -29,6 +29,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Slf4j
@@ -568,6 +569,42 @@ public class BoardService {
             throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
         }
 
+    }
+
+    /*
+    게시글 블라인드 또는 블라인드 해제 처리 (관리자용)
+     */
+    @Transactional
+    public ResponseEntity<?> blindBoard(long boardId) {
+        try {
+            Board findBoard = boardRepository.findByBoardIdNative(boardId).get();
+            findBoard.blindBoard();
+
+            return response.success("Blind Success!");
+
+        } catch (BoardException e) {
+            e.printStackTrace();
+            log.error("게시글 블라인드 처리 실패");
+            throw new BoardException(ErrorCode.BOARD_BLIND_FAIL);
+        }
+
+
+    }
+
+    /*
+    블라인드 된 게시글만 조회 (관리자용)
+     */
+    public ResponseEntity<?> blindBoardLookup(int page) {
+        try {
+            PageRequest pageRequest = PageRequest.of(page - 1, 10);
+            Slice<BoardDTO.boardResDTO> boardList = boardRepository.findBlindBoardNative(pageRequest).map(BoardDTO.boardResDTO::new);
+
+            return response.success(boardList, "Blind Board Lookup Success!");
+
+        } catch (BoardException e) {
+            log.error("게시글 리스트 조회 실패!");
+            throw new BoardException(ErrorCode.BOARD_LIST_INQUIRY_FAIL);
+        }
     }
 
     /*


### PR DESCRIPTION
## Motivation

관리자용 게시글 블라인드 처리 및 해제 기능, 블라인드 게시글만 조회 기능 구현하였습니다.
관리자만 사용가능하며 게시글 where어노테이션으로 인해 네이티브 쿼리 사용하였습니다.

## Key Changes

- 관리자용 게시글 블라인드 처리 및 해제
- 관리자용 블라인드 게시글만 조회

## To reviewers

코드 확인부탁드립니다!