### PR TITLE
refactor: 댓글 조회 시 페이징 처리되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/example/newfieldpasser/controller/BoardController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/BoardController.java
@@ -9,7 +9,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -24,7 +23,7 @@ public class BoardController {
     @PostMapping("/board/register")
     public ResponseEntity<?> registerBoard(@RequestParam(value = "file", required = false) MultipartFile file,
                                            Authentication authentication,
-                                           BoardDTO.boardReqDTO boardReqDTO) {
+                                           BoardDTO.BoardReqDTO boardReqDTO) {
 
         return boardService.registerBoard(file, authentication, boardReqDTO);
     }
@@ -47,7 +46,7 @@ public class BoardController {
     @PutMapping("/board/edit/{boardId}")
     public ResponseEntity<?> editBoard(@PathVariable long boardId,
                                        @RequestParam(value = "file", required = false) MultipartFile file,
-                                       BoardDTO.boardEditReqDTO boardEditReqDTO) {
+                                       BoardDTO.BoardEditReqDTO boardEditReqDTO) {
 
         return boardService.editBoard(boardId,file,boardEditReqDTO);
     }

--- a/src/main/java/com/example/newfieldpasser/controller/CommentController.java
+++ b/src/main/java/com/example/newfieldpasser/controller/CommentController.java
@@ -19,7 +19,7 @@ public class CommentController {
      */
 
     @PostMapping("/comment/write")
-    public ResponseEntity<?> registerComment(Authentication authentication, @RequestBody CommentDTO.commentReqDTO commentReqDTO){
+    public ResponseEntity<?> registerComment(Authentication authentication, @RequestBody CommentDTO.CommentReqDTO commentReqDTO){
         return commentService.registerComment(authentication,commentReqDTO);
     }
 
@@ -27,7 +27,7 @@ public class CommentController {
     댓글 수정
      */
     @PutMapping("/comment/edit/{commentId}")
-    public ResponseEntity<?> updateComment(@PathVariable long commentId, @RequestBody CommentDTO.commentUpdateDTO commentUpdateDTO){
+    public ResponseEntity<?> updateComment(@PathVariable long commentId, @RequestBody CommentDTO.CommentUpdateDTO commentUpdateDTO){
         return commentService.updateComment(commentId,commentUpdateDTO);
     }
 

--- a/src/main/java/com/example/newfieldpasser/dto/BoardDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/BoardDTO.java
@@ -5,7 +5,6 @@ import com.example.newfieldpasser.entity.Category;
 import com.example.newfieldpasser.entity.District;
 import com.example.newfieldpasser.entity.Member;
 import com.example.newfieldpasser.parameter.TransactionStatus;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -16,7 +15,7 @@ public class BoardDTO {
     @Getter
     @Setter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class boardReqDTO {
+    public static class BoardReqDTO {
 
         private String categoryName;
         private String districtName;
@@ -48,7 +47,7 @@ public class BoardDTO {
     @Getter
     @Setter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class boardEditReqDTO {
+    public static class BoardEditReqDTO {
 
         private String categoryName;
         private String districtName;
@@ -80,7 +79,7 @@ public class BoardDTO {
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class boardResDTO {
+    public static class BoardResDTO {
         private long boardId;
         private String memberId;
         private String memberName;
@@ -102,7 +101,7 @@ public class BoardDTO {
         private boolean deleteCheck;
 
         @Builder
-        public boardResDTO(Board board) {
+        public BoardResDTO(Board board) {
             this.boardId = board.getBoardId();
             this.memberId = board.getMember().getMemberId();
             this.memberName = board.getMember().getMemberName();
@@ -128,7 +127,7 @@ public class BoardDTO {
     @Getter
     @Setter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class boardDetailResDTO {
+    public static class BoardDetailResDTO {
         private long boardId;
         private String memberId;
         private String memberName;
@@ -152,7 +151,7 @@ public class BoardDTO {
         private boolean likeBoard;
 
         @Builder
-        public boardDetailResDTO(Board board) {
+        public BoardDetailResDTO(Board board) {
             this.boardId = board.getBoardId();
             this.memberId = board.getMember().getMemberId();
             this.memberName = board.getMember().getMemberName();

--- a/src/main/java/com/example/newfieldpasser/dto/CommentDTO.java
+++ b/src/main/java/com/example/newfieldpasser/dto/CommentDTO.java
@@ -4,7 +4,6 @@ import com.example.newfieldpasser.entity.Board;
 import com.example.newfieldpasser.entity.Comment;
 import com.example.newfieldpasser.entity.Member;
 import lombok.*;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -15,7 +14,7 @@ public class CommentDTO {
     @Getter
     @Setter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class commentReqDTO{
+    public static class CommentReqDTO {
         private String commentContent;
         private long boardId;
         private Long parentId;
@@ -32,7 +31,7 @@ public class CommentDTO {
     @Getter
     @Setter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class commentResDTO{
+    public static class CommentResDTO {
         private long commentId;
         private String memberId;
 
@@ -44,10 +43,10 @@ public class CommentDTO {
         private LocalDateTime commentRegisterDate;
         private LocalDateTime commentUpDate;
         private boolean myComment;
-        private List<commentResDTO> children = new ArrayList<>();
+        private List<CommentResDTO> children = new ArrayList<>();
 
         @Builder
-        public commentResDTO(Comment comment){
+        public CommentResDTO(Comment comment){
             this.commentId = comment.getCommentId();
             this.memberId = comment.getMember().getMemberId();
             this.memberNickname = comment.getMember().getMemberNickName();
@@ -67,7 +66,7 @@ public class CommentDTO {
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class commentUpdateDTO{
+    public static class CommentUpdateDTO {
         private String commentContent;
 
     }

--- a/src/main/java/com/example/newfieldpasser/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/example/newfieldpasser/repository/CommentRepositoryCustom.java
@@ -5,11 +5,10 @@ import com.example.newfieldpasser.entity.Comment;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepositoryCustom {
-   Slice<CommentDTO.commentResDTO> findByBoardId(Pageable pageable, long boardId);
+   Slice<CommentDTO.CommentResDTO> findByBoardId(Pageable pageable, long boardId);
 
    Optional<Comment> findCommentByIdWithParent(long commentId);
 }

--- a/src/main/java/com/example/newfieldpasser/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/example/newfieldpasser/repository/CommentRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.example.newfieldpasser.repository;
 
 import com.example.newfieldpasser.dto.CommentDTO;
-import com.example.newfieldpasser.dto.MypageDTO;
 import com.example.newfieldpasser.entity.Comment;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Pageable;
@@ -22,17 +21,17 @@ public class CommentRepositoryImpl extends QuerydslRepositorySupport implements 
 
 
     @Override
-    public Slice<CommentDTO.commentResDTO> findByBoardId(Pageable pageable,long boardId ) {
-        List<Comment> parentComments = queryFactory.selectFrom(comment)
-                .leftJoin(comment.parent).fetchJoin()
+    public Slice<CommentDTO.CommentResDTO> findByBoardId(Pageable pageable, long boardId ) {
+        List<Comment> parentComments =
+                queryFactory.selectFrom(comment)
                 .where(comment.board.boardId.eq(boardId), comment.parent.isNull())
                 .orderBy(comment.parent.commentId.asc().nullsFirst(), comment.commentRegisterDate.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
 
-        List<Comment> childrenComments = queryFactory.selectFrom(comment)
-                .leftJoin(comment.parent).fetchJoin()
+        List<Comment> childrenComments =
+                queryFactory.selectFrom(comment)
                 .where(comment.board.boardId.eq(boardId), comment.parent.isNotNull())
                 .orderBy(comment.parent.commentId.asc().nullsFirst(), comment.commentRegisterDate.asc())
                 .fetch();
@@ -43,12 +42,12 @@ public class CommentRepositoryImpl extends QuerydslRepositorySupport implements 
             hasNext = true;
         }
 
-        List<CommentDTO.commentResDTO> commentList = new ArrayList<>();
+        List<CommentDTO.CommentResDTO> commentList = new ArrayList<>();
 
         parentComments.forEach(p -> {
-            CommentDTO.commentResDTO parentResDTO = new CommentDTO.commentResDTO(p);
+            CommentDTO.CommentResDTO parentResDTO = new CommentDTO.CommentResDTO(p);
             childrenComments.forEach(c -> {
-                CommentDTO.commentResDTO childrenResDTO = new CommentDTO.commentResDTO(c);
+                CommentDTO.CommentResDTO childrenResDTO = new CommentDTO.CommentResDTO(c);
                 if (c.getParent().getCommentId() == p.getCommentId()) {
                     parentResDTO.getChildren().add(childrenResDTO);
                 }

--- a/src/main/java/com/example/newfieldpasser/service/BoardService.java
+++ b/src/main/java/com/example/newfieldpasser/service/BoardService.java
@@ -29,7 +29,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Slf4j
@@ -55,7 +54,7 @@ public class BoardService {
     게시글 등록
      */
     @Transactional
-    public ResponseEntity<?> registerBoard(MultipartFile file, Authentication authentication, BoardDTO.boardReqDTO boardReqDTO) {
+    public ResponseEntity<?> registerBoard(MultipartFile file, Authentication authentication, BoardDTO.BoardReqDTO boardReqDTO) {
         try {
             String imageUrl = null;
             if (file != null && !file.isEmpty()) {
@@ -110,7 +109,7 @@ public class BoardService {
      */
     public ResponseEntity<?> boardInquiryDetail(long boardId, Authentication authentication) {
         try {
-            BoardDTO.boardDetailResDTO result = boardRepository.findByBoardId(boardId).map(BoardDTO.boardDetailResDTO::new).get();
+            BoardDTO.BoardDetailResDTO result = boardRepository.findByBoardId(boardId).map(BoardDTO.BoardDetailResDTO::new).get();
 
             String loginMemberId = authentication != null ? authentication.getName() : "";
 
@@ -135,7 +134,7 @@ public class BoardService {
     게시글 수정
      */
     @Transactional
-    public ResponseEntity<?> editBoard(long boardId, MultipartFile file, BoardDTO.boardEditReqDTO boardEditReqDTO) {
+    public ResponseEntity<?> editBoard(long boardId, MultipartFile file, BoardDTO.BoardEditReqDTO boardEditReqDTO) {
         try {
 
             Board board = boardRepository.findByBoardId(boardId).get();
@@ -213,8 +212,8 @@ public class BoardService {
 
             PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
 
-            Slice<BoardDTO.boardResDTO> boardList =
-                    boardRepository.findDefaultAll(pageRequest).map(BoardDTO.boardResDTO::new);
+            Slice<BoardDTO.BoardResDTO> boardList =
+                    boardRepository.findDefaultAll(pageRequest).map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -232,8 +231,8 @@ public class BoardService {
 
             PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
 
-            Slice<BoardDTO.boardResDTO> boardList =
-                    boardRepository.findByCategory_CategoryId(categoryId, pageRequest).map(BoardDTO.boardResDTO::new);
+            Slice<BoardDTO.BoardResDTO> boardList =
+                    boardRepository.findByCategory_CategoryId(categoryId, pageRequest).map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -252,8 +251,8 @@ public class BoardService {
             List<Integer> districtIds = districtReqDTO.getDistrictIds();
             PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
 
-            Slice<BoardDTO.boardResDTO> boardList =
-                    boardRepository.findByDistricts(districtIds, pageRequest).map(BoardDTO.boardResDTO::new);
+            Slice<BoardDTO.BoardResDTO> boardList =
+                    boardRepository.findByDistricts(districtIds, pageRequest).map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -272,9 +271,9 @@ public class BoardService {
             List<Integer> districtIds = districtReqDTO.getDistrictIds();
             PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
 
-            Slice<BoardDTO.boardResDTO> boardList =
+            Slice<BoardDTO.BoardResDTO> boardList =
                     boardRepository.findByCategoryAndDistricts(categoryId, districtIds, pageRequest)
-                            .map(BoardDTO.boardResDTO::new);
+                            .map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -292,9 +291,9 @@ public class BoardService {
 
             PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
 
-            Slice<BoardDTO.boardResDTO> boardList =
+            Slice<BoardDTO.BoardResDTO> boardList =
                     boardRepository.findByTitleContaining(title, pageRequest)
-                            .map(BoardDTO.boardResDTO::new);
+                            .map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -312,9 +311,9 @@ public class BoardService {
 
             PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
 
-            Slice<BoardDTO.boardResDTO> boardList =
+            Slice<BoardDTO.BoardResDTO> boardList =
                     boardRepository.findByTitleContainingAndCategory_CategoryId(title, categoryId, pageRequest)
-                            .map(BoardDTO.boardResDTO::new);
+                            .map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -333,9 +332,9 @@ public class BoardService {
             List<Integer> districtIds = districtReqDTO.getDistrictIds();
             PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
 
-            Slice<BoardDTO.boardResDTO> boardList =
+            Slice<BoardDTO.BoardResDTO> boardList =
                     boardRepository.findByTitleAndDistricts(title, districtIds, pageRequest)
-                            .map(BoardDTO.boardResDTO::new);
+                            .map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -354,9 +353,9 @@ public class BoardService {
             List<Integer> districtIds = districtReqDTO.getDistrictIds();
             PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
 
-            Slice<BoardDTO.boardResDTO> boardList =
+            Slice<BoardDTO.BoardResDTO> boardList =
                     boardRepository.findByTitleAndCategoryAndDistricts(title, categoryId, districtIds, pageRequest)
-                            .map(BoardDTO.boardResDTO::new);
+                            .map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -377,10 +376,10 @@ public class BoardService {
             LocalDateTime start = LocalDateTime.parse(startTime);
             LocalDateTime end = LocalDateTime.parse(endTime);
 
-            Slice<BoardDTO.boardResDTO> boardList =
+            Slice<BoardDTO.BoardResDTO> boardList =
                     boardRepository
                             .findByDateAndTitleAndCategoryAndDistricts(title, categoryId, districtIds, start, end, pageRequest)
-                            .map(BoardDTO.boardResDTO::new);
+                            .map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -400,10 +399,10 @@ public class BoardService {
             LocalDateTime start = LocalDateTime.parse(startTime);
             LocalDateTime end = LocalDateTime.parse(endTime);
 
-            Slice<BoardDTO.boardResDTO> boardList =
+            Slice<BoardDTO.BoardResDTO> boardList =
                     boardRepository
                             .findByDateAndTitleAndCategory(title, categoryId, start, end, pageRequest)
-                            .map(BoardDTO.boardResDTO::new);
+                            .map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -424,10 +423,10 @@ public class BoardService {
             LocalDateTime start = LocalDateTime.parse(startTime);
             LocalDateTime end = LocalDateTime.parse(endTime);
 
-            Slice<BoardDTO.boardResDTO> boardList =
+            Slice<BoardDTO.BoardResDTO> boardList =
                     boardRepository
                             .findByDateAndTitleAndDistricts(title, districtIds, start, end, pageRequest)
-                            .map(BoardDTO.boardResDTO::new);
+                            .map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -446,10 +445,10 @@ public class BoardService {
             LocalDateTime start = LocalDateTime.parse(startTime);
             LocalDateTime end = LocalDateTime.parse(endTime);
 
-            Slice<BoardDTO.boardResDTO> boardList =
+            Slice<BoardDTO.BoardResDTO> boardList =
                     boardRepository
                             .findByDateAndTitle(title, start, end, pageRequest)
-                            .map(BoardDTO.boardResDTO::new);
+                            .map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -468,10 +467,10 @@ public class BoardService {
             LocalDateTime start = LocalDateTime.parse(startTime);
             LocalDateTime end = LocalDateTime.parse(endTime);
 
-            Slice<BoardDTO.boardResDTO> boardList =
+            Slice<BoardDTO.BoardResDTO> boardList =
                     boardRepository
                             .findByDate(start, end, pageRequest)
-                            .map(BoardDTO.boardResDTO::new);
+                            .map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -490,10 +489,10 @@ public class BoardService {
             LocalDateTime start = LocalDateTime.parse(startTime);
             LocalDateTime end = LocalDateTime.parse(endTime);
 
-            Slice<BoardDTO.boardResDTO> boardList =
+            Slice<BoardDTO.BoardResDTO> boardList =
                     boardRepository
                             .findByDateAndCategory(start, end, categoryId, pageRequest)
-                            .map(BoardDTO.boardResDTO::new);
+                            .map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -513,10 +512,10 @@ public class BoardService {
             LocalDateTime start = LocalDateTime.parse(startTime);
             LocalDateTime end = LocalDateTime.parse(endTime);
 
-            Slice<BoardDTO.boardResDTO> boardList =
+            Slice<BoardDTO.BoardResDTO> boardList =
                     boardRepository
                             .findByDateAndDistrict(start, end, districtIds, pageRequest)
-                            .map(BoardDTO.boardResDTO::new);
+                            .map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -537,10 +536,10 @@ public class BoardService {
             LocalDateTime start = LocalDateTime.parse(startTime);
             LocalDateTime end = LocalDateTime.parse(endTime);
 
-            Slice<BoardDTO.boardResDTO> boardList =
+            Slice<BoardDTO.BoardResDTO> boardList =
                     boardRepository
                             .findByDateAndCategoryAndDistrict(start, end, categoryId, districtIds, pageRequest)
-                            .map(BoardDTO.boardResDTO::new);
+                            .map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -557,10 +556,10 @@ public class BoardService {
             LocalDateTime startTime = LocalDateTime.parse(start);
             LocalDateTime endTime = LocalDateTime.parse(end);
 
-            Slice<BoardDTO.boardResDTO> boardList =
+            Slice<BoardDTO.BoardResDTO> boardList =
                     boardRepository
                             .findBySearchOption(pageable, title, categoryName, districtNames, startTime, endTime)
-                            .map(BoardDTO.boardResDTO::new);
+                            .map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Board Inquiry Success!");
 
@@ -597,7 +596,7 @@ public class BoardService {
     public ResponseEntity<?> blindBoardLookup(int page) {
         try {
             PageRequest pageRequest = PageRequest.of(page - 1, 10);
-            Slice<BoardDTO.boardResDTO> boardList = boardRepository.findBlindBoardNative(pageRequest).map(BoardDTO.boardResDTO::new);
+            Slice<BoardDTO.BoardResDTO> boardList = boardRepository.findBlindBoardNative(pageRequest).map(BoardDTO.BoardResDTO::new);
 
             return response.success(boardList, "Blind Board Lookup Success!");
 

--- a/src/main/java/com/example/newfieldpasser/service/CommentService.java
+++ b/src/main/java/com/example/newfieldpasser/service/CommentService.java
@@ -15,6 +15,7 @@ import com.example.newfieldpasser.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
@@ -121,9 +122,8 @@ public class CommentService {
      */
     public ResponseEntity<?> commentListInquiryByBoard(long boardId ,int page, Authentication authentication){
         try{
-            PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.ASC, "commentRegisterDate"));
-            Slice<CommentDTO.commentResDTO> commentList= commentRepository
-                    .findByBoardId(pageRequest,boardId);
+            Pageable pageable = PageRequest.of(page - 1, 10);
+            Slice<CommentDTO.commentResDTO> commentList= commentRepository.findByBoardId(pageable,boardId);
 
             String loginMemberId = authentication != null ? authentication.getName() : "";
             commentList.getContent().forEach(p -> {

--- a/src/main/java/com/example/newfieldpasser/service/CommentService.java
+++ b/src/main/java/com/example/newfieldpasser/service/CommentService.java
@@ -8,7 +8,6 @@ import com.example.newfieldpasser.entity.Comment;
 import com.example.newfieldpasser.entity.Member;
 import com.example.newfieldpasser.exception.comment.CommentException;
 import com.example.newfieldpasser.exception.comment.ErrorCode;
-import com.example.newfieldpasser.exception.member.MemberException;
 import com.example.newfieldpasser.repository.BoardRepository;
 import com.example.newfieldpasser.repository.CommentRepository;
 import com.example.newfieldpasser.repository.MemberRepository;
@@ -40,7 +39,7 @@ public class CommentService {
         댓글 생성
      */
     @Transactional
-    public ResponseEntity<?> registerComment (Authentication authentication, CommentDTO.commentReqDTO commentReqDTO){
+    public ResponseEntity<?> registerComment (Authentication authentication, CommentDTO.CommentReqDTO commentReqDTO){
         try{
             Member member = memberRepository.findByMemberId(authentication.getName()).get();
             Board board = boardRepository.findByBoardId(commentReqDTO.getBoardId()).get();
@@ -69,7 +68,7 @@ public class CommentService {
        댓글 수정
     */
     @Transactional
-    public ResponseEntity<?> updateComment(long commentId, CommentDTO.commentUpdateDTO commentUpdateDTO){
+    public ResponseEntity<?> updateComment(long commentId, CommentDTO.CommentUpdateDTO commentUpdateDTO){
         try{
 
             Comment comment = commentRepository.findByCommentId(commentId).get();
@@ -123,7 +122,7 @@ public class CommentService {
     public ResponseEntity<?> commentListInquiryByBoard(long boardId ,int page, Authentication authentication){
         try{
             Pageable pageable = PageRequest.of(page - 1, 10);
-            Slice<CommentDTO.commentResDTO> commentList= commentRepository.findByBoardId(pageable,boardId);
+            Slice<CommentDTO.CommentResDTO> commentList= commentRepository.findByBoardId(pageable,boardId);
 
             String loginMemberId = authentication != null ? authentication.getName() : "";
             commentList.getContent().forEach(p -> {
@@ -149,7 +148,7 @@ public class CommentService {
             String memberId = authentication.getName();
 
             PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "commentRegisterDate"));
-            Slice<CommentDTO.commentResDTO> commentList = commentRepository.findByMember_MemberId(memberId,pageRequest).map(CommentDTO.commentResDTO :: new);
+            Slice<CommentDTO.CommentResDTO> commentList = commentRepository.findByMember_MemberId(memberId,pageRequest).map(CommentDTO.CommentResDTO:: new);
 
             if(commentList.isEmpty()){
                 return response.success(commentList,"작성한 댓글이 없습니다.");

--- a/src/main/java/com/example/newfieldpasser/service/MemberService.java
+++ b/src/main/java/com/example/newfieldpasser/service/MemberService.java
@@ -4,9 +4,7 @@ import com.example.newfieldpasser.dto.AuthDTO;
 import com.example.newfieldpasser.dto.BoardDTO;
 import com.example.newfieldpasser.dto.MypageDTO;
 import com.example.newfieldpasser.dto.Response;
-import com.example.newfieldpasser.entity.Board;
 import com.example.newfieldpasser.entity.Member;
-import com.example.newfieldpasser.exception.board.BoardException;
 import com.example.newfieldpasser.exception.member.ErrorCode;
 import com.example.newfieldpasser.exception.member.MemberException;
 import com.example.newfieldpasser.jwt.JwtTokenProvider;
@@ -15,7 +13,6 @@ import com.example.newfieldpasser.repository.MemberRepository;
 import com.example.newfieldpasser.vo.MailVo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.cache.spi.entry.StructuredCacheEntry;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -27,9 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
-import java.util.List;
 import java.util.Random;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -360,7 +355,7 @@ public class MemberService {
             String memberId = authentication.getName();
 
             PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "registerDate"));
-                Slice<BoardDTO.boardResDTO> myBoardList = boardRepository.findByMember_MemberId(memberId,pageRequest).map(BoardDTO.boardResDTO::new);
+                Slice<BoardDTO.BoardResDTO> myBoardList = boardRepository.findByMember_MemberId(memberId,pageRequest).map(BoardDTO.BoardResDTO::new);
 
 
                 if (myBoardList.isEmpty()){


### PR DESCRIPTION
## Motivation

댓글 조회 시 페이징 처리되지 않는 문제 일단 해결하였습니다.

1차 문제
- 쿼리에 offset, limit 설정을 하지 않아 댓글 조회 시 페이징 처리되지 않고 페이지 번호와 관련 없이 데이터 전체 출력

2차 문제
- offset, limit 설정하였으나 부모댓글과 자식댓글을 다시 구성하는 과정에서 NPE가 발생
- offset과 limit 때문에 한정된 데이터를 가져오다보니 한 테이블에 있는 부모댓글과 자식댓글 데이터를 다시 구성하는 과정이 잘못되었던 것 같습니다.

해결방법
- 우선, 페이징 처리된 부모댓글들만 뽑아온다.
- 전체 자식 댓글들 뽑아온다.
- 반복문을 통해 부모댓글에 자식댓글을 넣어준다.

일단은 이렇게 해결했습니다. 더 좋은 방법 찾아주세요..

## Key Changes

- 댓글 조회 시 페이징 처리되지 않는 문제 해결
- 추가로 DTO 맨 앞글자 대문자로 통일했습니다.

## To reviewers

코드 확인부탁드립니다
